### PR TITLE
chore: remove gnureadline dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
     - config
     - datasets
     - docker
-    - gnureadline
     - gymnasium
     - numpy
     - openai>=1.0

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setuptools.setup(
         'config',
         'datasets',
         'docker',
-        'gnureadline',
         'gymnasium',
         'numpy',
         'openai>=1.0',


### PR DESCRIPTION
requirement is not used anywhere and causes a setup failure on windows as the dependency cannot be used with windows