### PR TITLE
fix: allow token from keys.cfg to get passed to ghapi

### DIFF
--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -83,11 +83,6 @@ class SWEEnv(gym.Env):
             logger.warning("Failed to get commit hash for this repo")
             self.commit_sha = None
 
-        # Load Task Instances
-        self.data_path = self.args.data_path
-        self.data = get_instances(self.data_path, self.args.base_commit, self.args.split)
-        self.logger.info(f"💽 Loaded dataset from {self.data_path}")
-
         # Set GitHub Token
         self.token = os.environ.get("GITHUB_TOKEN", None)
         if (self.token is None or self.token == "") and os.path.isfile(
@@ -95,6 +90,11 @@ class SWEEnv(gym.Env):
         ):
             self.cfg = config.Config(os.path.join(os.getcwd(), "keys.cfg"))
             self.token = self.cfg.get("GITHUB_TOKEN", "git")
+
+        # Load Task Instances
+        self.data_path = self.args.data_path
+        self.data = get_instances(self.data_path, self.args.base_commit, self.args.split, token=self.token)
+        self.logger.info(f"💽 Loaded dataset from {self.data_path}")
 
         # Establish connection with execution container
         self.image_name = args.image_name
@@ -642,7 +642,7 @@ class SWEEnv(gym.Env):
                 pass
             else:
                 raise ValueError(f"Invalid command type: {command['type']}")
-        
+
     def interrupt(self):
         """
         Send interrupt signal to container and exhaust stdout buffer with a communicate call

--- a/sweagent/environment/utils.py
+++ b/sweagent/environment/utils.py
@@ -48,7 +48,7 @@ def copy_file_to_container(container, contents, container_path):
     - container: Docker SDK container object.
     - contents: The string to copy into the container.
     - container_path: The path inside the container where the string should be copied to.
-    
+
     Returns:
     - None
     """
@@ -126,7 +126,7 @@ def read_with_timeout(container, pid_func, timeout_duration):
     if time.time() >= end_time:
         raise TimeoutError("Timeout reached while reading from subprocess.\nCurrent buffer: {}\nRunning PIDs: {}".format(buffer.decode(), pids))
     return buffer.decode()
-    
+
 
 class timeout:
     def __init__(self, seconds=TIMEOUT_DURATION, error_message="Timeout"):
@@ -231,7 +231,7 @@ def _get_persistent_container(ctr_name: str, image_name: str, persistent: bool =
         stdout=PIPE,
         stderr=STDOUT,
         text=True,
-        bufsize=1, # line buffered 
+        bufsize=1, # line buffered
     )
     time.sleep(START_UP_DELAY)
     # try to read output from container setup (usually an error), timeout if no output
@@ -279,7 +279,7 @@ def get_commit(api: GhApi, owner: str, repo: str, base_commit: str = None):
 
 
 
-def get_instances(file_path: str, base_commit: str = None, split: str = None):
+def get_instances(file_path: str, base_commit: str = None, split: str = None, token: str = None):
     """
     Getter function for handling json, jsonl files
 
@@ -295,7 +295,7 @@ def get_instances(file_path: str, base_commit: str = None, split: str = None):
     # If file_path is a github issue url, fetch the issue and return a single instance
     if is_from_github_url(file_path):
         match = GITHUB_ISSUE_URL_PATTERN.search(file_path)
-        api = GhApi()
+        api = GhApi(token=token)
         if match:
             owner, repo, issue_number = match.groups()
             record = dict()
@@ -317,7 +317,7 @@ def get_instances(file_path: str, base_commit: str = None, split: str = None):
         return json.load(open(file_path))
     if file_path.endswith(".jsonl"):
         return [json.loads(x) for x in open(file_path, 'r').readlines()]
-    
+
     # Attempt load from HF datasets as a last resort
     try:
         return load_dataset(file_path, split=split)


### PR DESCRIPTION
Currently running with the setup defined in the README the `python run.py ...` will fail at `get_instances` because `GhApi` reads the github token from environment variables.

Setup:

keys.cfg
```
OPENAI_API_TOKEN="xxx"
GITHUB_TOKEN="xxxx"
```

Ensure GITHUB_TOKEN is not exported in environment:

`unset GITHUB_TOKEN`

Command:

```
python run.py --model_name gpt4   --data_path https://github.com/tcoyze/calendly-webhook/issues/1   --config_file config/default_from_url.yaml
```

Example error:

```
...

/home/tyler/miniconda3/envs/swe-agent/lib/python3.9/site-packages/ghapi/core.py:102: UserWarning: Neither GITHUB_TOKEN nor GITHUB_JWT_TOKEN found: running as unauthenticated
  else: warn('Neither GITHUB_TOKEN nor GITHUB_JWT_TOKEN found: running as unauthenticated')
Traceback (most recent call last):
  File "/home/tyler/workspaces/princeton-nlp/SWE-agent/run.py", line 223, in <module>
    main(args)
  File "/home/tyler/workspaces/princeton-nlp/SWE-agent/run.py", line 66, in main
    env = SWEEnv(args.environment)
  File "/home/tyler/workspaces/princeton-nlp/SWE-agent/sweagent/environment/swe_env.py", line 88, in __init__
    self.data = get_instances(self.data_path, self.args.base_commit, self.args.split)
  File "/home/tyler/workspaces/princeton-nlp/SWE-agent/sweagent/environment/utils.py", line 302, in get_instances
    issue = api.issues.get(owner, repo, issue_number)
  File "/home/tyler/miniconda3/envs/swe-agent/lib/python3.9/site-packages/ghapi/core.py", line 62, in __call__
    return self.client(self.path, self.verb, headers=headers, route=route_p, query=query_p, data=data_p)
  File "/home/tyler/miniconda3/envs/swe-agent/lib/python3.9/site-packages/ghapi/core.py", line 121, in __call__
    res,self.recv_hdrs = urlsend(path, verb, headers=headers or None, debug=debug, return_headers=True,
  File "/home/tyler/miniconda3/envs/swe-agent/lib/python3.9/site-packages/fastcore/net.py", line 218, in urlsend
    return urlread(req, return_json=return_json, return_headers=return_headers)
  File "/home/tyler/miniconda3/envs/swe-agent/lib/python3.9/site-packages/fastcore/net.py", line 119, in urlread
    if 400 <= e.code < 500: raise ExceptionsHTTP[e.code](e.url, e.hdrs, e.fp, msg=e.msg) from None
fastcore.net.HTTP404NotFoundError: HTTP Error 404: Not Found
====Error Body====
{
  "message": "Not Found",
  "documentation_url": "https://docs.github.com/rest/issues/issues#get-an-issue"
}
```

This PR updates SWEEnv class and the get_instances util function so that a token is passed regardless of where the token was defined (env var, or keys.cfg).

⚠️ **NOTE** It also updates the formatting of the files I touched (happy to remove though!).

I personally think the repo should move towards a `.env` file. However, that decision could be discussed after this.

I hope this helps others!