### PR TITLE
add TOGETHER_API_KEY to keys.cfg section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ Read our paper for more details.
 4. Run `./setup.sh` to create the `swe-agent` docker image.
 5. Create a `keys.cfg` file at the root of this repository and fill in the following:
 ```
+GITHUB_TOKEN: 'GitHub Token Here (required)'
 OPENAI_API_KEY: 'OpenAI API Key Here if using OpenAI Model (optional)'
 ANTHROPIC_API_KEY: 'Anthropic API Key Here if using Anthropic Model (optional)'
-GITHUB_TOKEN: 'GitHub Token Here (required)'
+TOGETHER_API_KEY: 'Together API Key Here if using Together Model (optional)'
 ```
 See the following links for tutorials on obtaining [Anthropic](https://docs.anthropic.com/claude/reference/getting-started-with-the-api), [OpenAI](https://platform.openai.com/docs/quickstart/step-2-set-up-your-api-key), and [Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) tokens.
 


### PR DESCRIPTION
I noticed there is also a `TOGETHER_API_KEY` key that can be set in `keys.cfg` while I was investigating https://github.com/princeton-nlp/SWE-agent/issues/26#issuecomment-2035899278, but it wasn't mentioned in the README, so I wanted to add it:

https://github.com/princeton-nlp/SWE-agent/blob/6c9ebf0ea8a263806b276da7ba3b1eda1f4a9475/sweagent/agent/models.py#L509-L511

I also moved the `GITHUB_TOKEN` to the top of the list, since it's a required token.