### PR TITLE
Feat: Open PR to repo

### DIFF
--- a/run.py
+++ b/run.py
@@ -50,7 +50,7 @@ class ActionsArguments(FlattenedAccess, FrozenSerializable):
         if not self.skip_if_commits_reference_issue and self.push_gh_repo_url:
             raise ValueError(
                 "Overriding `skip_if_commits_reference_issue` when you are "
-                "pushing to a fork is not supported. You can always manually "
+                "pushing to a fork is not supported. You should manually "
                 "apply the patch to the forked repository."
             )
 
@@ -163,7 +163,7 @@ def should_open_pr(args, info: Dict[str, Any], *, token: str="") -> bool:
     try:
         issue = get_gh_issue_data(args.environment.data_path, token=token)
     except InvalidGithubURL:
-        logger.info("Currently only github is supported to open githubs to. Skipping PR creation.")
+        logger.info("Currently only github is supported to open PRs to. Skipping PR creation.")
         return False
     if issue.state != "open":
         logger.info(f"Issue is not open (state={issue.state}. Skipping PR creation.")

--- a/run.py
+++ b/run.py
@@ -123,16 +123,16 @@ def main(args: ScriptArguments):
                 "test_files": test_files,
                 "tests": tests
             }
-            info = agent.run(
+            info, trajectory = agent.run(
                 setup_args=setup_args,
                 env=env,
                 observation=observation,
                 traj_dir=traj_dir,
-                return_type="info",
+                return_type="info_trajectory",
             )
             save_predictions(traj_dir, instance_id, info)
             if args.actions.open_pr and should_open_pr(args, info, token=env.token):
-                env.open_pr(args.actions)
+                env.open_pr(args.actions, info, trajectory)
 
         except KeyboardInterrupt:
             logger.info("Exiting InterCode environment...")

--- a/run.py
+++ b/run.py
@@ -46,6 +46,13 @@ class ActionsArguments(FlattenedAccess, FrozenSerializable):
     # permissions to push to the main repo), set this to the URL of the fork.
     push_gh_repo_url: str = ""
 
+    def __post_init__(self):
+        if not self.skip_if_commits_reference_issue and self.push_gh_repo_url:
+            raise ValueError(
+                "Overriding `skip_if_commits_reference_issue` when you are "
+                "pushing to a fork is not supported. You can always manually "
+                "apply the patch to the forked repository."
+            )
 
 @dataclass(frozen=True)
 class ScriptArguments(FlattenedAccess, FrozenSerializable):

--- a/run_replay.py
+++ b/run_replay.py
@@ -108,8 +108,8 @@ def process_single_traj(traj_path: str, config_file: str, data_path: str, suffix
         command.extend(["--suffix", suffix])
     subprocess.run(command)
 
-    os.remove(replay_action_trajs_path)
-    os.remove(replay_task_instances_path)
+    # os.remove(replay_action_trajs_path)
+    # os.remove(replay_task_instances_path)
 
 
 def main(

--- a/run_replay.py
+++ b/run_replay.py
@@ -108,8 +108,8 @@ def process_single_traj(traj_path: str, config_file: str, data_path: str, suffix
         command.extend(["--suffix", suffix])
     subprocess.run(command)
 
-    # os.remove(replay_action_trajs_path)
-    # os.remove(replay_task_instances_path)
+    os.remove(replay_action_trajs_path)
+    os.remove(replay_task_instances_path)
 
 
 def main(

--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -675,7 +675,9 @@ class Agent:
             info['model_stats'] = self.model.stats.to_dict()
             if traj_dir:
                 self.save_trajectory(trajectory, traj_dir, env, info)
+        if return_type == "info":
+            return info
+        if return_type == "info_trajectory":
+            return info, trajectory
         if return_type != "info":
             return trajectory[-1][return_type]
-        else:
-            return info

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -675,7 +675,7 @@ class SWEEnv(gym.Env):
             raise RuntimeError("Failed to interrupt container")
 
 
-    def open_pr(self, action_config: "ActionsArguments", info, trajectory):
+    def open_pr(self, action_config, info, trajectory):
         """Create PR to repository"""
         logger.info("Opening PR")
         # todo: have better way of handling this

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -678,8 +678,8 @@ class SWEEnv(gym.Env):
         logger.info("Opening PR")
         # todo: have better way of handling this
         # Adding random string suffix to avoid name conflicts if we had a previously failed run
-        # todo: add issue number to branch name
-        branch_name = "swe-agent-patch-branch-" + str(random.random())[2:10]
+        issue = get_gh_issue_data(issue_url, token=self.token)
+        branch_name = f"swe-agent-fix-#{issue.number}-" + str(random.random())[2:10]
         issue_url = self.args.data_path 
 
         self.communicate_with_handling(
@@ -697,7 +697,6 @@ class SWEEnv(gym.Env):
             error_msg="Failed to add commits",
             timeout_duration=10,
         )
-        issue = get_gh_issue_data(issue_url, token=self.token)
         self.communicate_with_handling(
             input=f"git commit -m 'Fix: {issue.title}' -m 'Closes #{issue.number}' ",
             error_msg="Failed to commit changes",

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -678,9 +678,9 @@ class SWEEnv(gym.Env):
         logger.info("Opening PR")
         # todo: have better way of handling this
         # Adding random string suffix to avoid name conflicts if we had a previously failed run
+        issue_url = self.args.data_path 
         issue = get_gh_issue_data(issue_url, token=self.token)
         branch_name = f"swe-agent-fix-#{issue.number}-" + str(random.random())[2:10]
-        issue_url = self.args.data_path 
 
         self.communicate_with_handling(
             input=f"rm model.patch",

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -18,6 +18,7 @@ from rich.logging import RichHandler
 from simple_parsing.helpers import FrozenSerializable
 from sweagent.environment.utils import (
     copy_file_to_container,
+    format_trajectory_markdown,
     get_container,
     get_gh_issue_data,
     get_instances,
@@ -674,7 +675,7 @@ class SWEEnv(gym.Env):
             raise RuntimeError("Failed to interrupt container")
 
 
-    def open_pr(self, action_config: "ActionsArguments"):
+    def open_pr(self, action_config: "ActionsArguments", info, trajectory):
         """Create PR to repository"""
         logger.info("Opening PR")
         # todo: have better way of handling this
@@ -732,6 +733,7 @@ class SWEEnv(gym.Env):
             f"This is a PR opened by AI tool [SWE Agent](https://github.com/princeton-nlp/SWE-agent/) " 
             f"to close [#{issue.number}]({issue_url}) ({issue.title}).\n\nCloses #{issue.number}."
         )
+        body += "\n\n" + format_trajectory_markdown(trajectory)
         api = GhApi(token=self.token)
         pr_info = api.pulls.create(
             owner=owner,

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -468,7 +468,7 @@ class SWEEnv(gym.Env):
 
     def communicate_with_handling(
         self, input: str, error_msg: str, timeout_duration=25
-    ):
+    ) -> str:
         """
         Wrapper for communicate function that raises error if return code is non-zero
         """
@@ -477,6 +477,7 @@ class SWEEnv(gym.Env):
             self.logger.error(f"{error_msg}: {logs}")
             self.close()
             raise RuntimeError(f"{error_msg}: {logs}")
+        return logs
 
     def get_available_actions(self) -> list[str]:
         """

--- a/sweagent/environment/utils.py
+++ b/sweagent/environment/utils.py
@@ -295,6 +295,15 @@ def parse_gh_issue_url(issue_url: str) -> Tuple[str, str, str]:
     return tuple(res)  # type: ignore
 
 
+def parse_gh_repo_url(repo_url: str) -> Tuple[str, str]:
+    """Return owner, repo from repo url"""
+    if not repo_url.startswith('http://') and not repo_url.startswith('https://'):
+        repo_url = 'https://' + repo_url
+    parts = repo_url.split('/')
+    owner = parts[3] 
+    repo = parts[4]
+    return owner, repo
+
 
 def get_gh_issue_data(issue_url: str, *, token: str = ""):
     """Returns github issue data in the form of a dictionary.


### PR DESCRIPTION
Example PR: https://github.com/klieret/swe-agent-test-repo/pull/12

## Safeguards

* PR is only created as draft and has to be manually marked as "ready for review"

PRs only get created if

* swe-agent reports success
* issue is open
* no one is assigned to issue
* no commit references the issue as 'closes #xx' (can be overridden)
* issue is not locked

## Progress

* [x] Move code to SWE-env
* [x] Make use of `ghapi` instead of `requests`
* [x] Logging instead of printing
* [x] Check that issue was still open
* [x] Check that no one was assigned to the issue
* [x] Create "Action" config instead of adding open_pr
* [x] Deal with forked repositories (separate repository where branch is being pushed)
* [x] Print PR url
* [x] Check if there are already hanging PRs to issue
* [ ] Add readme

Optional/separate PR:

* [ ] Include summary of actions in body?
* [x] Include trajectory in body --> later

Closes #8 

Also thanks to @themrzmaster who opened a PR for the same issue in #37.