### PR TITLE
fix: bad newline getting sent on windows

### DIFF
--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -413,7 +413,7 @@ class SWEEnv(gym.Env):
         try:
             self.returncode = None
             cmd = input if input.endswith("\n") else input + "\n"
-            self.container.stdin.write(cmd)
+            os.write(self.container.stdin.fileno(), cmd.encode())
             time.sleep(0.1)
             self.container.stdin.flush()
         except BrokenPipeError:


### PR DESCRIPTION
Fixes an issue with windows where `\r\n` is getting sent to the docker image instead of `\n`. This is documented in the [subprocess](https://docs.python.org/3/library/subprocess.html) api as it replaces `\n` with `os.linesep`. With #17, this can be fully run on windows now