### PR TITLE
Containerize application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9
+
+# Set the working directory
+WORKDIR /app
+
+# Install Python dependencies
+RUN pip install anthropic config datasets docker gymnasium numpy openai pandas rich ruamel.yaml swebench tenacity unidiff simple-parsing together ollama
+
+# Install Docker CLI using the official Docker installation script
+RUN curl -fsSL https://get.docker.com -o get-docker.sh && \
+    sh get-docker.sh
+
+# Copy the application code
+# Do this last to take advantage of the docker layer mechanism
+COPY . /app
+


### PR DESCRIPTION
Part of a solution to #66 and might help people running Windows as well.

Current way of running this:

```bash
docker build -t swe-agent-run:latest .  && \
docker run -it -v /var/run/docker.sock:/var/run/docker.sock --rm swe-agent-run:latest  \
python3 run.py --model_name gpt4 \
  --data_path  https://github.com/klieret/swe-agent-test-repo/issues/1 \
  --config_file config/default_from_url.yaml
```

Closes #28 

## Tasks

* [x] ~~Add `run.py` as default entry point~~ let's not do this. we might have more executables in here in the future and this doesn't really make things simpler
* [ ] Push working version to dockerhub
* [ ] Push swe-agent container to dockerhub
* [ ] Add instruction to readme