### PR TITLE
Remove azure override of model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ ANTHROPIC_API_KEY: 'Anthropic API Key Here if using Anthropic Model (optional)'
 TOGETHER_API_KEY: 'Together API Key Here if using Together Model (optional)'
 AZURE_OPENAI_API_KEY: 'Azure OpenAI API Key Here if using Azure OpenAI Model (optional)'
 AZURE_OPENAI_ENDPOINT: 'Azure OpenAI Endpoint Here if using Azure OpenAI Model (optional)'
-AZURE_OPENAI_DEPLOYMENT: 'Azure OpenAI Deployment Here if using Azure OpenAI Model (optional)'
 AZURE_OPENAI_API_VERSION: 'Azure OpenAI API Version Here if using Azure OpenAI Model (optional)'
 OPENAI_API_BASE_URL: 'LLM base URL here if using Local or alternative api Endpoint (optional)'
 ```  

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -224,7 +224,6 @@ class OpenAIModel(BaseModel):
         # Set OpenAI key
         cfg = config.Config(os.path.join(os.getcwd(), "keys.cfg"))
         if self.args.model_name.startswith("azure"):
-            self.api_model = cfg["AZURE_OPENAI_DEPLOYMENT"]
             self.client = AzureOpenAI(api_key=cfg["AZURE_OPENAI_API_KEY"], azure_endpoint=cfg["AZURE_OPENAI_ENDPOINT"], api_version=cfg.get("AZURE_OPENAI_API_VERSION", "2024-02-01"))
         else:
             api_base_url: Optional[str] = cfg.get("OPENAI_API_BASE_URL", None)


### PR DESCRIPTION
This is a fixup to #16. We shouldn't simply override the `--model_name` option from the CLI with something from `keys.cfg`