### PR TITLE
feat(agents): support Azure deployment with `--model`

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,19 @@ python run.py --model_name gpt4 \
 * See the [`trajectories/`](trajectories) folder for details about the output of `run.py`.
 
 <details>
+<summary> Azure OpenAI support</summary>
+
+Azure OpenAI models can be used by specifying `--model` with `azure:azure_deployment_name`.
+
+```bash
+python run.py --model_name azure:my-gpt-35-turbo \
+  --data_path https://github.com/pvlib/pvlib-python/issues/1603 \
+  --config_file config/default_from_url.yaml
+```
+
+</details>
+
+<details>
 <summary> Ollama Support</summary>
 
 Models served with an ollama server can be used by specifying `--model` with `ollama:model_name` and `--host_url` to point to the url used to serve ollama (`http://localhost:11434` by default). See more details about using ollama [here](https://github.com/ollama/ollama/tree/main/docs).
@@ -172,6 +185,7 @@ python run.py --model_name ollama:deepseek-coder:6.7b-instruct \
   --config_file config/default_from_url.yaml
 ```
 </details>
+
 
 ## 💽 Benchmarking <a name="benchmarking"></a>
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ ANTHROPIC_API_KEY: 'Anthropic API Key Here if using Anthropic Model (optional)'
 TOGETHER_API_KEY: 'Together API Key Here if using Together Model (optional)'
 AZURE_OPENAI_API_KEY: 'Azure OpenAI API Key Here if using Azure OpenAI Model (optional)'
 AZURE_OPENAI_ENDPOINT: 'Azure OpenAI Endpoint Here if using Azure OpenAI Model (optional)'
-AZURE_OPENAI_DEPLOYMENT: 'Azure OpenAI Deployment Here if using Azure OpenAI Model (optional)'
 AZURE_OPENAI_API_VERSION: 'Azure OpenAI API Version Here if using Azure OpenAI Model (optional)'
 OPENAI_API_BASE_URL: 'LM base URL here if using Local or alternative api Endpoint (optional)'
 ```  

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -226,7 +226,7 @@ class OpenAIModel(BaseModel):
         print(">>>>>>>>", cfg)
         print(">>>>>>", OpenAI)
         if self.args.model_name.startswith("azure"):
-            self.api_model = self.args.model_name.split("azure")[1] 
+            self.api_model = self.args.model_name.split("azure:")[1] 
             self.client = AzureOpenAI(api_key=cfg["AZURE_OPENAI_API_KEY"], azure_endpoint=cfg["AZURE_OPENAI_ENDPOINT"], api_version=cfg.get("AZURE_OPENAI_API_VERSION", "2024-02-01"))
         else:
             api_base_url: Optional[str] = cfg.get("OPENAI_API_BASE_URL", None)

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -226,7 +226,7 @@ class OpenAIModel(BaseModel):
         print(">>>>>>>>", cfg)
         print(">>>>>>", OpenAI)
         if self.args.model_name.startswith("azure"):
-            self.api_model = cfg["AZURE_OPENAI_DEPLOYMENT"]
+            self.api_model = self.args.model_name.split("azure")[1] 
             self.client = AzureOpenAI(api_key=cfg["AZURE_OPENAI_API_KEY"], azure_endpoint=cfg["AZURE_OPENAI_ENDPOINT"], api_version=cfg.get("AZURE_OPENAI_API_VERSION", "2024-02-01"))
         else:
             api_base_url: Optional[str] = cfg.get("OPENAI_API_BASE_URL", None)


### PR DESCRIPTION
#### What does this implement/fix? 
This PR removes the unnecessary environment variable `AZURE_OPENAI_DEPLOYMENT` and parses the model passed to the container/script instead.

Since the prefix of `--model` is used to discriminate whether to use OpenAI, Azure OpenAI, Ollama, Claude etc., the deployment name shouldn't be specified again  in `keys.cfg`. 

