### PR TITLE
Improve --help message option headers

### DIFF
--- a/run.py
+++ b/run.py
@@ -57,6 +57,7 @@ class ActionsArguments(FlattenedAccess, FrozenSerializable):
 
 @dataclass(frozen=True)
 class ScriptArguments(FlattenedAccess, FrozenSerializable):
+    """Configure the control flow of the run.py script"""
     environment: EnvironmentArguments
     agent: AgentArguments
     actions: ActionsArguments

--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -179,6 +179,7 @@ class AgentConfig(FrozenSerializable):
 
 @dataclass(frozen=True)
 class AgentArguments(FlattenedAccess, FrozenSerializable):
+    """Configure the agent's behaviour (templates, parse functions, blocklists, ...)."""
     model: ModelArguments = None
 
     # Policy can only be set via config yaml file from command line

--- a/sweagent/agent/commands.py
+++ b/sweagent/agent/commands.py
@@ -72,7 +72,6 @@ class ParseCommand(metaclass=ParseCommandMeta):
 
 class ParseCommandBash(ParseCommand):
     def parse_command_file(self, path: str) -> List[Command]:
-        print('Parsing command file:', path)
         contents = open(path, "r").read()
         if contents.strip().startswith("#!"):
             commands = self.parse_script(path, contents)

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -23,6 +23,7 @@ logger = logging.getLogger("api_models")
 
 @dataclass(frozen=True)
 class ModelArguments(FrozenSerializable):
+    """Arguments configuring the model and its behavior."""
     model_name: str
     per_instance_cost_limit: float = 0.0
     total_cost_limit: float = 0.0

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -51,6 +51,8 @@ logger.propagate = False
 
 @dataclass(frozen=True)
 class EnvironmentArguments(FrozenSerializable):
+    """Configure data sources and setup instructions for th environment in which we solve the tasks.
+    """
     data_path: str
     image_name: str
     split: str = "dev"


### PR DESCRIPTION
The docstrings of the argument dataclasses are also used in the --help
message. If they aren't set, the signature of the dataclass is shown
instead.
