### PR TITLE
parse single line code for action

### DIFF
--- a/sweagent/agent/parsing.py
+++ b/sweagent/agent/parsing.py
@@ -127,6 +127,15 @@ class ThoughtActionParser(ParseFunction):
             start, end = last_valid_block
             thought = model_response[:start.start()] + model_response[end.end():]
             return thought, model_response[start.end():end.start()]
+        
+        # No multiline code, look for single line code
+        code_block_pat = re.compile(r'```(.*?)```')
+        match = code_block_pat.search(model_response)
+        if match:
+            thought = model_response[:match.start()] + model_response[match.end():]
+            return thought, match.group(1)
+        
+        # No single line code, raise error
         raise FormatError("No action found in model response.")
 
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -36,6 +36,12 @@ def test_thought_action_parser():
     with pytest.raises(FormatError):
         parser("No code block", [])
 
+    # Single line code block test
+    model_response = "Let's look at the files in the current directory.\n```ls -l```"
+    thought, action = parser(model_response, [])
+    assert thought == "Let's look at the files in the current directory.\n"
+    assert action == "ls -l"
+
 
 def test_xml_thought_action_parser():
     parser = XMLThoughtActionParser()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
<!--
Example: "Fixes #1234", "See also #3456"
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #297 

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->

- Add parsing for single-line code block as fallback of multi-line code block
- Add test for single-line code block

#### Any other comments?

I'm testing with llama3-8b model, which has limited ability. Maybe models capable of the SWE bench will never make such mistake, but I didn't test this. I'm opening this PR anyway, in case it's helpful.
