### PR TITLE
fix: typo in root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Just like how typical language models requires good prompt engineering, good ACI
 SWE-agent contains features that we discovered to be immensely helpful during the agent-computer interface design process:
 1. We add a linter that runs when an edit command is issued, and do not let the edit command go through if the code isn't syntactically correct.
 2. We supply the agent with a special-built file viewer, instead of having it just ```cat``` files. We found that this file viewer works best when displaying just 100 lines in each turn. The file editor that we built has commands for scrolling up and down and for performing a search within the file.
-3. We supply the agent with a special-built full-directory string searching command. We found that it was important for this tool to succintly list the matches- we simply list each file that had at least one match. Showing the model more context about each match proved to be too confusing for the model. 
+3. We supply the agent with a special-built full-directory string searching command. We found that it was important for this tool to succinctly list the matches- we simply list each file that had at least one match. Showing the model more context about each match proved to be too confusing for the model. 
 4. When commands have an empty output we return a message saying "Your command ran successfully and did not produce any output."
 
 Read our paper for more details [coming soon!].


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Fixes a tiny typo in the root README :')

#### Any other comments?

You're doing amazing work.