### PR TITLE
Fix: Do not request job control in bash

### DIFF
--- a/sweagent/environment/utils.py
+++ b/sweagent/environment/utils.py
@@ -253,7 +253,6 @@ def _get_non_persistent_container(ctr_name: str, image_name: str) -> Tuple[subpr
         image_name,
         "/bin/bash",
         "-l",
-        "-m",
     ]
     logger.debug(f"Starting container with command: %s", shlex.join(startup_cmd))
     container = subprocess.Popen(
@@ -305,7 +304,6 @@ def _get_persistent_container(ctr_name: str, image_name: str, persistent: bool =
         ctr_name,
         "/bin/bash",
         "-l",
-        "-m",
     ]
     logger.debug(f"Starting container with command: %s", shlex.join(startup_cmd))
     container = subprocess.Popen(


### PR DESCRIPTION
Closes #331

It's unlikely that job control was ever granted. Currently we're getting

ERROR    Unexpected container setup output: /bin/bash: cannot set terminal process group (-1): Inappropriate ioctl for device
         /bin/bash: no job control in this shell

Because of this.
