### PR TITLE
Improve context by providing a repo map; Add Vertex AI integration; Add Greedy action parser for more robust code block action syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ var/
 wheels/
 pip-wheel-metadata/
 share/python-wheels/
+workspace/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ AZURE_OPENAI_ENDPOINT: 'Azure OpenAI Endpoint Here if using Azure OpenAI Model'
 AZURE_OPENAI_DEPLOYMENT: 'Azure OpenAI Deployment Here if using Azure OpenAI Model'
 AZURE_OPENAI_API_VERSION: 'Azure OpenAI API Version Here if using Azure OpenAI Model'
 OPENAI_API_BASE_URL: 'LM base URL here if using Local or alternative api Endpoint'
-```  
+```
 </details>
 
 See the following links for tutorials on obtaining [Anthropic](https://docs.anthropic.com/claude/reference/getting-started-with-the-api), [OpenAI](https://platform.openai.com/docs/quickstart/step-2-set-up-your-api-key), and [Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) tokens.

--- a/aiderrepomap/dump.py
+++ b/aiderrepomap/dump.py
@@ -1,0 +1,29 @@
+import json
+import traceback
+
+
+def cvt(s):
+    if isinstance(s, str):
+        return s
+    try:
+        return json.dumps(s, indent=4)
+    except TypeError:
+        return str(s)
+
+
+def dump(*vals):
+    # http://docs.python.org/library/traceback.html
+    stack = traceback.extract_stack()
+    vars = stack[-2][3]
+
+    # strip away the call to dump()
+    vars = "(".join(vars.split("(")[1:])
+    vars = ")".join(vars.split(")")[:-1])
+
+    vals = [cvt(v) for v in vals]
+    has_newline = sum(1 for v in vals if "\n" in v)
+    if has_newline:
+        print("%s:" % vars)
+        print(", ".join(vals))
+    else:
+        print("%s:" % vars, ", ".join(vals))

--- a/aiderrepomap/io.py
+++ b/aiderrepomap/io.py
@@ -1,0 +1,362 @@
+import os
+from collections import defaultdict
+from datetime import datetime
+import base64
+from pathlib import Path
+
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.history import FileHistory
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.lexers import PygmentsLexer
+from prompt_toolkit.shortcuts import CompleteStyle, PromptSession, prompt
+from prompt_toolkit.styles import Style
+from pygments.lexers import MarkdownLexer, guess_lexer_for_filename
+from pygments.token import Token
+from pygments.util import ClassNotFound
+from rich.console import Console
+from rich.text import Text
+
+from aiderrepomap.utils import is_image_file
+from aiderrepomap.dump import dump  # noqa: F401
+
+
+class AutoCompleter(Completer):
+    def __init__(self, root, rel_fnames, addable_rel_fnames, commands, encoding):
+        self.commands = commands
+        self.addable_rel_fnames = addable_rel_fnames
+        self.rel_fnames = rel_fnames
+        self.encoding = encoding
+
+        fname_to_rel_fnames = defaultdict(list)
+        for rel_fname in addable_rel_fnames:
+            fname = os.path.basename(rel_fname)
+            if fname != rel_fname:
+                fname_to_rel_fnames[fname].append(rel_fname)
+        self.fname_to_rel_fnames = fname_to_rel_fnames
+
+        self.words = set()
+
+        for rel_fname in addable_rel_fnames:
+            self.words.add(rel_fname)
+
+        for rel_fname in rel_fnames:
+            self.words.add(rel_fname)
+
+            fname = Path(root) / rel_fname
+            try:
+                with open(fname, "r", encoding=self.encoding) as f:
+                    content = f.read()
+            except (FileNotFoundError, UnicodeDecodeError):
+                continue
+            try:
+                lexer = guess_lexer_for_filename(fname, content)
+            except ClassNotFound:
+                continue
+            tokens = list(lexer.get_tokens(content))
+            self.words.update(token[1] for token in tokens if token[0] in Token.Name)
+
+    def get_completions(self, document, complete_event):
+        text = document.text_before_cursor
+        words = text.split()
+        if not words:
+            return
+
+        if text[0] == "/":
+            if len(words) == 1 and not text[-1].isspace():
+                candidates = self.commands.get_commands()
+                candidates = [(cmd, cmd) for cmd in candidates]
+            else:
+                for completion in self.commands.get_command_completions(words[0][1:], words[-1]):
+                    yield completion
+                return
+        else:
+            candidates = self.words
+            candidates.update(set(self.fname_to_rel_fnames))
+            candidates = [(word, f"`{word}`") for word in candidates]
+
+        last_word = words[-1]
+        for word_match, word_insert in candidates:
+            if word_match.lower().startswith(last_word.lower()):
+                rel_fnames = self.fname_to_rel_fnames.get(word_match, [])
+                if rel_fnames:
+                    for rel_fname in rel_fnames:
+                        yield Completion(
+                            f"`{rel_fname}`", start_position=-len(last_word), display=rel_fname
+                        )
+                else:
+                    yield Completion(
+                        word_insert, start_position=-len(last_word), display=word_match
+                    )
+
+
+class InputOutput:
+    num_error_outputs = 0
+    num_user_asks = 0
+
+    def __init__(
+        self,
+        pretty=True,
+        yes=False,
+        input_history_file=None,
+        chat_history_file=None,
+        input=None,
+        output=None,
+        user_input_color="blue",
+        tool_output_color=None,
+        tool_error_color="red",
+        encoding="utf-8",
+        dry_run=False,
+    ):
+        no_color = os.environ.get("NO_COLOR")
+        if no_color is not None and no_color != "":
+            pretty = False
+
+        self.user_input_color = user_input_color if pretty else None
+        self.tool_output_color = tool_output_color if pretty else None
+        self.tool_error_color = tool_error_color if pretty else None
+
+        self.input = input
+        self.output = output
+
+        self.pretty = pretty
+        if self.output:
+            self.pretty = False
+
+        self.yes = yes
+
+        self.input_history_file = input_history_file
+        if chat_history_file is not None:
+            self.chat_history_file = Path(chat_history_file)
+        else:
+            self.chat_history_file = None
+
+        self.encoding = encoding
+        self.dry_run = dry_run
+
+        if pretty:
+            self.console = Console()
+        else:
+            self.console = Console(force_terminal=False, no_color=True)
+
+        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.append_chat_history(f"\n# aider chat started at {current_time}\n\n")
+
+
+    def read_image(self, filename):
+        try:
+            with open(str(filename), "rb") as image_file:
+                encoded_string = base64.b64encode(image_file.read())
+                return encoded_string.decode('utf-8')
+        except FileNotFoundError:
+            self.tool_error(f"{filename}: file not found error")
+            return
+        except IsADirectoryError:
+            self.tool_error(f"{filename}: is a directory")
+            return
+        except Exception as e:
+            self.tool_error(f"{filename}: {e}")
+            return
+
+    def read_text(self, filename):
+        if is_image_file(filename):
+            return self.read_image(filename)
+
+        try:
+            with open(str(filename), "r", encoding=self.encoding) as f:
+                return f.read()
+        except FileNotFoundError:
+            self.tool_error(f"{filename}: file not found error")
+            return
+        except IsADirectoryError:
+            self.tool_error(f"{filename}: is a directory")
+            return
+        except UnicodeError as e:
+            self.tool_error(f"{filename}: {e}")
+            self.tool_error("Use --encoding to set the unicode encoding.")
+            return
+
+    def write_text(self, filename, content):
+        if self.dry_run:
+            return
+        with open(str(filename), "w", encoding=self.encoding) as f:
+            f.write(content)
+
+    def get_input(self, root, rel_fnames, addable_rel_fnames, commands):
+        if self.pretty:
+            style = dict(style=self.user_input_color) if self.user_input_color else dict()
+            self.console.rule(**style)
+        else:
+            print()
+
+        rel_fnames = list(rel_fnames)
+        show = " ".join(rel_fnames)
+        if len(show) > 10:
+            show += "\n"
+        show += "> "
+
+        inp = ""
+        multiline_input = False
+
+        if self.user_input_color:
+            style = Style.from_dict(
+                {
+                    "": self.user_input_color,
+                    "pygments.literal.string": f"bold italic {self.user_input_color}",
+                }
+            )
+        else:
+            style = None
+
+        while True:
+            completer_instance = AutoCompleter(
+                root, rel_fnames, addable_rel_fnames, commands, self.encoding
+            )
+            if multiline_input:
+                show = ". "
+
+            session_kwargs = {
+                "message": show,
+                "completer": completer_instance,
+                "reserve_space_for_menu": 4,
+                "complete_style": CompleteStyle.MULTI_COLUMN,
+                "input": self.input,
+                "output": self.output,
+                "lexer": PygmentsLexer(MarkdownLexer),
+            }
+            if style:
+                session_kwargs["style"] = style
+
+            if self.input_history_file is not None:
+                session_kwargs["history"] = FileHistory(self.input_history_file)
+
+            kb = KeyBindings()
+
+            @kb.add("escape", "c-m", eager=True)
+            def _(event):
+                event.current_buffer.insert_text("\n")
+
+            session = PromptSession(key_bindings=kb, **session_kwargs)
+            line = session.prompt()
+
+            if line and line[0] == "{" and not multiline_input:
+                multiline_input = True
+                inp += line[1:] + "\n"
+                continue
+            elif line and line[-1] == "}" and multiline_input:
+                inp += line[:-1] + "\n"
+                break
+            elif multiline_input:
+                inp += line + "\n"
+            else:
+                inp = line
+                break
+
+        print()
+        self.user_input(inp)
+        return inp
+
+    def add_to_input_history(self, inp):
+        if not self.input_history_file:
+            return
+        FileHistory(self.input_history_file).append_string(inp)
+
+    def get_input_history(self):
+        if not self.input_history_file:
+            return []
+
+        fh = FileHistory(self.input_history_file)
+        return fh.load_history_strings()
+
+    def user_input(self, inp, log_only=True):
+        if not log_only:
+            style = dict(style=self.user_input_color) if self.user_input_color else dict()
+            self.console.print(inp, **style)
+
+        prefix = "####"
+        if inp:
+            hist = inp.splitlines()
+        else:
+            hist = ["<blank>"]
+
+        hist = f"  \n{prefix} ".join(hist)
+
+        hist = f"""
+{prefix} {hist}"""
+        self.append_chat_history(hist, linebreak=True)
+
+    # OUTPUT
+
+    def ai_output(self, content):
+        hist = "\n" + content.strip() + "\n\n"
+        self.append_chat_history(hist)
+
+    def confirm_ask(self, question, default="y"):
+        self.num_user_asks += 1
+
+        if self.yes is True:
+            res = "yes"
+        elif self.yes is False:
+            res = "no"
+        else:
+            res = prompt(question + " ", default=default)
+
+        hist = f"{question.strip()} {res.strip()}"
+        self.append_chat_history(hist, linebreak=True, blockquote=True)
+        if self.yes in (True, False):
+            self.tool_output(hist)
+
+        if not res or not res.strip():
+            return
+        return res.strip().lower().startswith("y")
+
+    def prompt_ask(self, question, default=None):
+        self.num_user_asks += 1
+
+        if self.yes is True:
+            res = "yes"
+        elif self.yes is False:
+            res = "no"
+        else:
+            res = prompt(question + " ", default=default)
+
+        hist = f"{question.strip()} {res.strip()}"
+        self.append_chat_history(hist, linebreak=True, blockquote=True)
+        if self.yes in (True, False):
+            self.tool_output(hist)
+
+        return res
+
+    def tool_error(self, message):
+        self.num_error_outputs += 1
+
+        if message.strip():
+            hist = f"{message.strip()}"
+            self.append_chat_history(hist, linebreak=True, blockquote=True)
+
+        message = Text(message)
+        style = dict(style=self.tool_error_color) if self.tool_error_color else dict()
+        self.console.print(message, **style)
+
+    def tool_output(self, *messages, log_only=False):
+        if messages:
+            hist = " ".join(messages)
+            hist = f"{hist.strip()}"
+            self.append_chat_history(hist, linebreak=True, blockquote=True)
+
+        if not log_only:
+            messages = list(map(Text, messages))
+            style = dict(style=self.tool_output_color) if self.tool_output_color else dict()
+            self.console.print(*messages, **style)
+
+    def append_chat_history(self, text, linebreak=False, blockquote=False):
+        if blockquote:
+            text = text.strip()
+            text = "> " + text
+        if linebreak:
+            text = text.rstrip()
+            text = text + "  \n"
+        if not text.endswith("\n"):
+            text += "\n"
+        if self.chat_history_file is not None:
+            with self.chat_history_file.open("a", encoding=self.encoding) as f:
+                f.write(text)

--- a/aiderrepomap/queries/tree-sitter-c-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-c-tags.scm
@@ -1,0 +1,9 @@
+(struct_specifier name: (type_identifier) @name.definition.class body:(_)) @definition.class
+
+(declaration type: (union_specifier name: (type_identifier) @name.definition.class)) @definition.class
+
+(function_declarator declarator: (identifier) @name.definition.function) @definition.function
+
+(type_definition declarator: (type_identifier) @name.definition.type) @definition.type
+
+(enum_specifier name: (type_identifier) @name.definition.type) @definition.type

--- a/aiderrepomap/queries/tree-sitter-c_sharp-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-c_sharp-tags.scm
@@ -1,0 +1,46 @@
+(class_declaration
+ name: (identifier) @name.definition.class
+ ) @definition.class
+
+(class_declaration
+   bases: (base_list (_) @name.reference.class)
+ ) @reference.class
+
+(interface_declaration
+ name: (identifier) @name.definition.interface
+ ) @definition.interface
+
+(interface_declaration
+ bases: (base_list (_) @name.reference.interface)
+ ) @reference.interface
+
+(method_declaration
+ name: (identifier) @name.definition.method
+ ) @definition.method
+
+(object_creation_expression
+ type: (identifier) @name.reference.class
+ ) @reference.class
+
+(type_parameter_constraints_clause
+ target: (identifier) @name.reference.class
+ ) @reference.class
+
+(type_constraint
+ type: (identifier) @name.reference.class
+ ) @reference.class
+
+(variable_declaration
+ type: (identifier) @name.reference.class
+ ) @reference.class
+
+(invocation_expression
+ function:
+  (member_access_expression
+    name: (identifier) @name.reference.send
+ )
+) @reference.send
+
+(namespace_declaration
+ name: (identifier) @name.definition.module
+) @definition.module

--- a/aiderrepomap/queries/tree-sitter-cpp-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-cpp-tags.scm
@@ -1,0 +1,15 @@
+(struct_specifier name: (type_identifier) @name.definition.class body:(_)) @definition.class
+
+(declaration type: (union_specifier name: (type_identifier) @name.definition.class)) @definition.class
+
+(function_declarator declarator: (identifier) @name.definition.function) @definition.function
+
+(function_declarator declarator: (field_identifier) @name.definition.function) @definition.function
+
+(function_declarator declarator: (qualified_identifier scope: (namespace_identifier) @scope name: (identifier) @name.definition.method)) @definition.method
+
+(type_definition declarator: (type_identifier) @name.definition.type) @definition.type
+
+(enum_specifier name: (type_identifier) @name.definition.type) @definition.type
+
+(class_specifier name: (type_identifier) @name.definition.class) @definition.class

--- a/aiderrepomap/queries/tree-sitter-elisp-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-elisp-tags.scm
@@ -1,0 +1,8 @@
+;; defun/defsubst
+(function_definition name: (symbol) @name.definition.function) @definition.function
+
+;; Treat macros as function definitions for the sake of TAGS.
+(macro_definition name: (symbol) @name.definition.function) @definition.function
+
+;; Match function calls
+(list (symbol) @name.reference.function) @reference.function

--- a/aiderrepomap/queries/tree-sitter-elixir-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-elixir-tags.scm
@@ -1,0 +1,54 @@
+; Definitions
+
+; * modules and protocols
+(call
+  target: (identifier) @ignore
+  (arguments (alias) @name.definition.module)
+  (#match? @ignore "^(defmodule|defprotocol)$")) @definition.module
+
+; * functions/macros
+(call
+  target: (identifier) @ignore
+  (arguments
+    [
+      ; zero-arity functions with no parentheses
+      (identifier) @name.definition.function
+      ; regular function clause
+      (call target: (identifier) @name.definition.function)
+      ; function clause with a guard clause
+      (binary_operator
+        left: (call target: (identifier) @name.definition.function)
+        operator: "when")
+    ])
+  (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp)$")) @definition.function
+
+; References
+
+; ignore calls to kernel/special-forms keywords
+(call
+  target: (identifier) @ignore
+  (#match? @ignore "^(def|defp|defdelegate|defguard|defguardp|defmacro|defmacrop|defn|defnp|defmodule|defprotocol|defimpl|defstruct|defexception|defoverridable|alias|case|cond|else|for|if|import|quote|raise|receive|require|reraise|super|throw|try|unless|unquote|unquote_splicing|use|with)$"))
+
+; ignore module attributes
+(unary_operator
+  operator: "@"
+  operand: (call
+    target: (identifier) @ignore))
+
+; * function call
+(call
+  target: [
+   ; local
+   (identifier) @name.reference.call
+   ; remote
+   (dot
+     right: (identifier) @name.reference.call)
+  ]) @reference.call
+
+; * pipe into function call
+(binary_operator
+  operator: "|>"
+  right: (identifier) @name.reference.call) @reference.call
+
+; * modules
+(alias) @name.reference.module @reference.module

--- a/aiderrepomap/queries/tree-sitter-elm-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-elm-tags.scm
@@ -1,0 +1,19 @@
+(value_declaration (function_declaration_left (lower_case_identifier) @name.definition.function)) @definition.function
+
+(function_call_expr (value_expr (value_qid) @name.reference.function)) @reference.function
+(exposed_value (lower_case_identifier) @name.reference.function)) @reference.function
+(type_annotation ((lower_case_identifier) @name.reference.function) (colon)) @reference.function
+
+(type_declaration ((upper_case_identifier) @name.definition.type) ) @definition.type
+
+(type_ref (upper_case_qid (upper_case_identifier) @name.reference.type)) @reference.type
+(exposed_type (upper_case_identifier) @name.reference.type)) @reference.type
+
+(type_declaration (union_variant (upper_case_identifier) @name.definition.union)) @definition.union
+
+(value_expr (upper_case_qid (upper_case_identifier) @name.reference.union)) @reference.union
+
+
+(module_declaration 
+    (upper_case_qid (upper_case_identifier)) @name.definition.module
+) @definition.module

--- a/aiderrepomap/queries/tree-sitter-go-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-go-tags.scm
@@ -1,0 +1,30 @@
+(
+  (comment)* @doc
+  .
+  (function_declaration
+    name: (identifier) @name.definition.function) @definition.function
+  (#strip! @doc "^//\\s*")
+  (#set-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (method_declaration
+    name: (field_identifier) @name.definition.method) @definition.method
+  (#strip! @doc "^//\\s*")
+  (#set-adjacent! @doc @definition.method)
+)
+
+(call_expression
+  function: [
+    (identifier) @name.reference.call
+    (parenthesized_expression (identifier) @name.reference.call)
+    (selector_expression field: (field_identifier) @name.reference.call)
+    (parenthesized_expression (selector_expression field: (field_identifier) @name.reference.call))
+  ]) @reference.call
+
+(type_spec
+  name: (type_identifier) @name.definition.type) @definition.type
+
+(type_identifier) @name.reference.type @reference.type

--- a/aiderrepomap/queries/tree-sitter-java-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-java-tags.scm
@@ -1,0 +1,20 @@
+(class_declaration
+  name: (identifier) @name.definition.class) @definition.class
+
+(method_declaration
+  name: (identifier) @name.definition.method) @definition.method
+
+(method_invocation
+  name: (identifier) @name.reference.call
+  arguments: (argument_list) @reference.call)
+
+(interface_declaration
+  name: (identifier) @name.definition.interface) @definition.interface
+
+(type_list
+  (type_identifier) @name.reference.implementation) @reference.implementation
+
+(object_creation_expression
+  type: (type_identifier) @name.reference.class) @reference.class
+
+(superclass (type_identifier) @name.reference.class) @reference.class

--- a/aiderrepomap/queries/tree-sitter-javascript-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-javascript-tags.scm
@@ -1,0 +1,88 @@
+(
+  (comment)* @doc
+  .
+  (method_definition
+    name: (property_identifier) @name.definition.method) @definition.method
+  (#not-eq? @name.definition.method "constructor")
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.method)
+)
+
+(
+  (comment)* @doc
+  .
+  [
+    (class
+      name: (_) @name.definition.class)
+    (class_declaration
+      name: (_) @name.definition.class)
+  ] @definition.class
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.class)
+)
+
+(
+  (comment)* @doc
+  .
+  [
+    (function
+      name: (identifier) @name.definition.function)
+    (function_declaration
+      name: (identifier) @name.definition.function)
+    (generator_function
+      name: (identifier) @name.definition.function)
+    (generator_function_declaration
+      name: (identifier) @name.definition.function)
+  ] @definition.function
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name.definition.function
+      value: [(arrow_function) (function)]) @definition.function)
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (variable_declaration
+    (variable_declarator
+      name: (identifier) @name.definition.function
+      value: [(arrow_function) (function)]) @definition.function)
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(assignment_expression
+  left: [
+    (identifier) @name.definition.function
+    (member_expression
+      property: (property_identifier) @name.definition.function)
+  ]
+  right: [(arrow_function) (function)]
+) @definition.function
+
+(pair
+  key: (property_identifier) @name.definition.function
+  value: [(arrow_function) (function)]) @definition.function
+
+(
+  (call_expression
+    function: (identifier) @name.reference.call) @reference.call
+  (#not-match? @name.reference.call "^(require)$")
+)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @name.reference.call)
+  arguments: (_) @reference.call)
+
+(new_expression
+  constructor: (_) @name.reference.class) @reference.class

--- a/aiderrepomap/queries/tree-sitter-ocaml-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-ocaml-tags.scm
@@ -1,0 +1,116 @@
+; Modules
+;--------
+
+(
+  (comment)? @doc .
+  (module_definition (module_binding (module_name) @name.definition.module) @definition.module)
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+(module_path (module_name) @name.reference.module) @reference.module
+
+; Modules types
+;--------------
+
+(
+  (comment)? @doc .
+  (module_type_definition (module_type_name) @name.definition.interface) @definition.interface
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+(module_type_path (module_type_name) @name.reference.implementation) @reference.implementation
+
+; Functions
+;----------
+
+(
+  (comment)? @doc .
+  (value_definition
+    [
+      (let_binding
+        pattern: (value_name) @name.definition.function
+        (parameter))
+      (let_binding
+        pattern: (value_name) @name.definition.function
+        body: [(fun_expression) (function_expression)])
+    ] @definition.function
+  )
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+(
+  (comment)? @doc .
+  (external (value_name) @name.definition.function) @definition.function
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+(application_expression
+  function: (value_path (value_name) @name.reference.call)) @reference.call
+
+(infix_expression
+  left: (value_path (value_name) @name.reference.call)
+  (infix_operator) @reference.call
+  (#eq? @reference.call "@@"))
+
+(infix_expression
+  (infix_operator) @reference.call
+  right: (value_path (value_name) @name.reference.call)
+  (#eq? @reference.call "|>"))
+
+; Operator
+;---------
+
+(
+  (comment)? @doc .
+  (value_definition
+    (let_binding
+      pattern: (parenthesized_operator [
+        (prefix_operator)
+        (infix_operator)
+        (hash_operator)
+        (indexing_operator)
+        (let_operator)
+        (and_operator)
+        (match_operator)
+      ] @name.definition.function)) @definition.function)
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+[
+  (prefix_operator)
+  (sign_operator)
+  (infix_operator)
+  (hash_operator)
+  (indexing_operator)
+  (let_operator)
+  (and_operator)
+  (match_operator)
+] @name.reference.call @reference.call
+
+; Classes
+;--------
+
+(
+  (comment)? @doc .
+  [
+    (class_definition (class_binding (class_name) @name.definition.class) @definition.class)
+    (class_type_definition (class_type_binding (class_type_name) @name.definition.class) @definition.class)
+  ]
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+[
+  (class_path (class_name) @name.reference.class)
+  (class_type_path (class_type_name) @name.reference.class)
+] @reference.class
+
+; Methods
+;--------
+
+(
+  (comment)? @doc .
+  (method_definition (method_name) @name.definition.method) @definition.method
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+(method_invocation (method_name) @name.reference.call) @reference.call

--- a/aiderrepomap/queries/tree-sitter-php-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-php-tags.scm
@@ -1,0 +1,26 @@
+(class_declaration
+  name: (name) @name.definition.class) @definition.class
+
+(function_definition
+  name: (name) @name.definition.function) @definition.function
+
+(method_declaration
+  name: (name) @name.definition.function) @definition.function
+
+(object_creation_expression
+  [
+    (qualified_name (name) @name.reference.class)
+    (variable_name (name) @name.reference.class)
+  ]) @reference.class
+
+(function_call_expression
+  function: [
+    (qualified_name (name) @name.reference.call)
+    (variable_name (name)) @name.reference.call
+  ]) @reference.call
+
+(scoped_call_expression
+  name: (name) @name.reference.call) @reference.call
+
+(member_call_expression
+  name: (name) @name.reference.call) @reference.call

--- a/aiderrepomap/queries/tree-sitter-python-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-python-tags.scm
@@ -1,0 +1,12 @@
+(class_definition
+  name: (identifier) @name.definition.class) @definition.class
+
+(function_definition
+  name: (identifier) @name.definition.function) @definition.function
+
+(call
+  function: [
+      (identifier) @name.reference.call
+      (attribute
+        attribute: (identifier) @name.reference.call)
+  ]) @reference.call

--- a/aiderrepomap/queries/tree-sitter-ql-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-ql-tags.scm
@@ -1,0 +1,26 @@
+(classlessPredicate
+  name: (predicateName) @name.definition.function) @definition.function
+
+(memberPredicate
+  name: (predicateName) @name.definition.method) @definition.method
+
+(aritylessPredicateExpr
+  name: (literalId) @name.reference.call) @reference.call
+
+(module
+  name: (moduleName) @name.definition.module) @definition.module
+
+(dataclass
+  name: (className) @name.definition.class) @definition.class
+
+(datatype
+  name: (className) @name.definition.class) @definition.class
+
+(datatypeBranch
+  name: (className) @name.definition.class) @definition.class
+
+(qualifiedRhs
+  name: (predicateName) @name.reference.call) @reference.call
+
+(typeExpr
+  name: (className) @name.reference.type) @reference.type

--- a/aiderrepomap/queries/tree-sitter-ruby-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-ruby-tags.scm
@@ -1,0 +1,64 @@
+; Method definitions
+
+(
+  (comment)* @doc
+  .
+  [
+    (method
+      name: (_) @name.definition.method) @definition.method
+    (singleton_method
+      name: (_) @name.definition.method) @definition.method
+  ]
+  (#strip! @doc "^#\\s*")
+  (#select-adjacent! @doc @definition.method)
+)
+
+(alias
+  name: (_) @name.definition.method) @definition.method
+
+(setter
+  (identifier) @ignore)
+
+; Class definitions
+
+(
+  (comment)* @doc
+  .
+  [
+    (class
+      name: [
+        (constant) @name.definition.class
+        (scope_resolution
+          name: (_) @name.definition.class)
+      ]) @definition.class
+    (singleton_class
+      value: [
+        (constant) @name.definition.class
+        (scope_resolution
+          name: (_) @name.definition.class)
+      ]) @definition.class
+  ]
+  (#strip! @doc "^#\\s*")
+  (#select-adjacent! @doc @definition.class)
+)
+
+; Module definitions
+
+(
+  (module
+    name: [
+      (constant) @name.definition.module
+      (scope_resolution
+        name: (_) @name.definition.module)
+    ]) @definition.module
+)
+
+; Calls
+
+(call method: (identifier) @name.reference.call) @reference.call
+
+(
+  [(identifier) (constant)] @name.reference.call @reference.call
+  (#is-not? local)
+  (#not-match? @name.reference.call "^(lambda|load|require|require_relative|__FILE__|__LINE__)$")
+)

--- a/aiderrepomap/queries/tree-sitter-rust-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-rust-tags.scm
@@ -1,0 +1,60 @@
+; ADT definitions
+
+(struct_item
+    name: (type_identifier) @name.definition.class) @definition.class
+
+(enum_item
+    name: (type_identifier) @name.definition.class) @definition.class
+
+(union_item
+    name: (type_identifier) @name.definition.class) @definition.class
+
+; type aliases
+
+(type_item
+    name: (type_identifier) @name.definition.class) @definition.class
+
+; method definitions
+
+(declaration_list
+    (function_item
+        name: (identifier) @name.definition.method)) @definition.method
+
+; function definitions
+
+(function_item
+    name: (identifier) @name.definition.function) @definition.function
+
+; trait definitions
+(trait_item
+    name: (type_identifier) @name.definition.interface) @definition.interface
+
+; module definitions
+(mod_item
+    name: (identifier) @name.definition.module) @definition.module
+
+; macro definitions
+
+(macro_definition
+    name: (identifier) @name.definition.macro) @definition.macro
+
+; references
+
+(call_expression
+    function: (identifier) @name.reference.call) @reference.call
+
+(call_expression
+    function: (field_expression
+        field: (field_identifier) @name.reference.call)) @reference.call
+
+(macro_invocation
+    macro: (identifier) @name.reference.call) @reference.call
+
+; implementations
+
+(impl_item
+    trait: (type_identifier) @name.reference.implementation) @reference.implementation
+
+(impl_item
+    type: (type_identifier) @name.reference.implementation
+    !trait) @reference.implementation

--- a/aiderrepomap/queries/tree-sitter-typescript-tags.scm
+++ b/aiderrepomap/queries/tree-sitter-typescript-tags.scm
@@ -1,0 +1,41 @@
+(function_signature
+  name: (identifier) @name.definition.function) @definition.function
+
+(method_signature
+  name: (property_identifier) @name.definition.method) @definition.method
+
+(abstract_method_signature
+  name: (property_identifier) @name.definition.method) @definition.method
+
+(abstract_class_declaration
+  name: (type_identifier) @name.definition.class) @definition.class
+
+(module
+  name: (identifier) @name.definition.module) @definition.module
+
+(interface_declaration
+  name: (type_identifier) @name.definition.interface) @definition.interface
+
+(type_annotation
+  (type_identifier) @name.reference.type) @reference.type
+
+(new_expression
+  constructor: (identifier) @name.reference.class) @reference.class
+
+(function_declaration
+  name: (identifier) @name.definition.function) @definition.function
+
+(method_definition
+  name: (property_identifier) @name.definition.method) @definition.method
+
+(class_declaration
+  name: (type_identifier) @name.definition.class) @definition.class
+
+(interface_declaration
+  name: (type_identifier) @name.definition.class) @definition.class
+
+(type_alias_declaration
+  name: (type_identifier) @name.definition.type) @definition.type
+
+(enum_declaration
+  name: (identifier) @name.definition.enum) @definition.enum

--- a/aiderrepomap/repo.py
+++ b/aiderrepomap/repo.py
@@ -1,0 +1,178 @@
+import os
+from pathlib import Path, PurePosixPath
+
+import git
+import pathspec
+
+from aiderrepomap import utils
+
+from .dump import dump  # noqa: F401
+
+
+class GitRepo:
+    repo = None
+    aider_ignore_file = None
+    aider_ignore_spec = None
+    aider_ignore_ts = 0
+
+    def __init__(self, io, fnames, git_dname, aider_ignore_file=None, client=None):
+        self.client = client
+        self.io = io
+
+        if git_dname:
+            check_fnames = [git_dname]
+        elif fnames:
+            check_fnames = fnames
+        else:
+            check_fnames = ["."]
+
+        repo_paths = []
+        for fname in check_fnames:
+            fname = Path(fname)
+            fname = fname.resolve()
+
+            if not fname.exists() and fname.parent.exists():
+                fname = fname.parent
+
+            try:
+                repo_path = git.Repo(fname, search_parent_directories=True).working_dir
+                repo_path = utils.safe_abs_path(repo_path)
+                repo_paths.append(repo_path)
+            except git.exc.InvalidGitRepositoryError:
+                pass
+            except git.exc.NoSuchPathError:
+                pass
+
+        num_repos = len(set(repo_paths))
+
+        if num_repos == 0:
+            raise FileNotFoundError
+        if num_repos > 1:
+            self.io.tool_error("Files are in different git repos.")
+            raise FileNotFoundError
+
+        # https://github.com/gitpython-developers/GitPython/issues/427
+        self.repo = git.Repo(repo_paths.pop(), odbt=git.GitDB)
+        self.root = utils.safe_abs_path(self.repo.working_tree_dir)
+
+        if aider_ignore_file:
+            self.aider_ignore_file = Path(aider_ignore_file)
+
+    def get_rel_repo_dir(self):
+        try:
+            return os.path.relpath(self.repo.git_dir, os.getcwd())
+        except ValueError:
+            return self.repo.git_dir
+
+    def get_diffs(self, fnames=None):
+        # We always want diffs of index and working dir
+
+        current_branch_has_commits = False
+        try:
+            active_branch = self.repo.active_branch
+            try:
+                commits = self.repo.iter_commits(active_branch)
+                current_branch_has_commits = any(commits)
+            except git.exc.GitCommandError:
+                pass
+        except TypeError:
+            pass
+
+        if not fnames:
+            fnames = []
+
+        diffs = ""
+        for fname in fnames:
+            if not self.path_in_repo(fname):
+                diffs += f"Added {fname}\n"
+
+        if current_branch_has_commits:
+            args = ["HEAD", "--"] + list(fnames)
+            diffs += self.repo.git.diff(*args)
+            return diffs
+
+        wd_args = ["--"] + list(fnames)
+        index_args = ["--cached"] + wd_args
+
+        diffs += self.repo.git.diff(*index_args)
+        diffs += self.repo.git.diff(*wd_args)
+
+        return diffs
+
+    def diff_commits(self, pretty, from_commit, to_commit):
+        args = []
+        if pretty:
+            args += ["--color"]
+
+        args += [from_commit, to_commit]
+        diffs = self.repo.git.diff(*args)
+
+        return diffs
+
+    def get_tracked_files(self):
+        if not self.repo:
+            return []
+
+        try:
+            commit = self.repo.head.commit
+        except ValueError:
+            commit = None
+
+        files = []
+        if commit:
+            for blob in commit.tree.traverse():
+                if blob.type == "blob":  # blob is a file
+                    files.append(blob.path)
+
+        # Add staged files
+        index = self.repo.index
+        staged_files = [path for path, _ in index.entries.keys()]
+
+        files.extend(staged_files)
+
+        # convert to appropriate os.sep, since git always normalizes to /
+        res = set(self.normalize_path(path) for path in files)
+
+        res = [fname for fname in res if not self.ignored_file(fname)]
+
+        return res
+
+    def normalize_path(self, path):
+        return str(Path(PurePosixPath((Path(self.root) / path).relative_to(self.root))))
+
+    def ignored_file(self, fname):
+        if not self.aider_ignore_file or not self.aider_ignore_file.is_file():
+            return
+
+        try:
+            fname = self.normalize_path(fname)
+        except ValueError:
+            return
+
+        mtime = self.aider_ignore_file.stat().st_mtime
+        if mtime != self.aider_ignore_ts:
+            self.aider_ignore_ts = mtime
+            lines = self.aider_ignore_file.read_text().splitlines()
+            self.aider_ignore_spec = pathspec.PathSpec.from_lines(
+                pathspec.patterns.GitWildMatchPattern,
+                lines,
+            )
+
+        return self.aider_ignore_spec.match_file(fname)
+
+    def path_in_repo(self, path):
+        if not self.repo:
+            return
+
+        tracked_files = set(self.get_tracked_files())
+        return self.normalize_path(path) in tracked_files
+
+    def abs_root_path(self, path):
+        res = Path(self.root) / path
+        return utils.safe_abs_path(res)
+
+    def is_dirty(self, path=None):
+        if path and not self.path_in_repo(path):
+            return True
+
+        return self.repo.is_dirty(path=path)

--- a/aiderrepomap/swe_repomap.py
+++ b/aiderrepomap/swe_repomap.py
@@ -1,0 +1,442 @@
+import os
+from collections import Counter, defaultdict, namedtuple
+from pathlib import Path
+
+import networkx as nx
+from diskcache import Cache
+from grep_ast import TreeContext, filename_to_lang
+from pygments.lexers import guess_lexer_for_filename
+from pygments.token import Token
+from pygments.util import ClassNotFound
+from tqdm import tqdm
+from tree_sitter_languages import get_language, get_parser
+
+from aiderrepomap import utils
+from aiderrepomap.io import InputOutput
+from aiderrepomap.repo import GitRepo
+
+Tag = namedtuple("Tag", "rel_fname fname line name kind".split())
+
+
+class RepoMap:
+    CACHE_VERSION = 3
+    TAGS_CACHE_DIR = f".aider.tags.cache.v{CACHE_VERSION}"
+
+    cache_missing = False
+
+    warned_files = set()
+
+    def __init__(
+        self,
+        map_tokens=16000,
+        root=None,
+        io=None,
+        repo_content_prefix=None,
+        verbose=False,
+    ):
+        if io is None:
+            io = InputOutput()
+        self.io = io
+        self.verbose = verbose
+
+        if not root:
+            root = os.getcwd()
+        self.root = root
+
+        self.load_tags_cache()
+
+        self.max_map_tokens = map_tokens
+
+        self.repo_content_prefix = repo_content_prefix
+        self.repo = GitRepo(io, None, root)
+
+    def get_repo_map_of_files(self, chat_files, other_files):
+        if self.max_map_tokens <= 0:
+            return
+
+        if not other_files:
+            return
+
+        try:
+            files_listing = self.get_ranked_tags_map(chat_files, other_files)
+        except RecursionError:
+            self.io.tool_error("Disabling repo map, git repo too large?")
+            self.max_map_tokens = 0
+            return
+        if not files_listing:
+            return
+
+        num_tokens = self.token_count(files_listing)
+        if self.verbose:
+            self.io.tool_output(f"Repo-map: {num_tokens/1024:.1f} k-tokens")
+
+        if chat_files:
+            other = "other "
+        else:
+            other = ""
+
+        if self.repo_content_prefix:
+            repo_content = self.repo_content_prefix.format(other=other)
+        else:
+            repo_content = ""
+
+        repo_content += files_listing
+
+        return repo_content
+
+    # TODO replace approximation
+    def token_count(self, string):
+        return len(string) / 3
+
+    def get_rel_fname(self, fname):
+        return os.path.relpath(fname, self.root)
+
+    def split_path(self, path):
+        path = os.path.relpath(path, self.root)
+        return [path + ":"]
+
+    def load_tags_cache(self):
+        path = Path(self.root) / self.TAGS_CACHE_DIR
+        if not path.exists():
+            self.cache_missing = True
+        self.TAGS_CACHE = Cache(path)
+
+    def save_tags_cache(self):
+        pass
+
+    def get_mtime(self, fname):
+        try:
+            return os.path.getmtime(fname)
+        except FileNotFoundError:
+            self.io.tool_error(f"File not found error: {fname}")
+
+    def get_tags(self, fname, rel_fname):
+        # Check if the file is in the cache and if the modification time has not changed
+        file_mtime = self.get_mtime(fname)
+        if file_mtime is None:
+            return []
+
+        cache_key = fname
+        if cache_key in self.TAGS_CACHE and self.TAGS_CACHE[cache_key]["mtime"] == file_mtime:
+            return self.TAGS_CACHE[cache_key]["data"]
+
+        # miss!
+
+        data = list(self.get_tags_raw(fname, rel_fname))
+
+        # Update the cache
+        self.TAGS_CACHE[cache_key] = {"mtime": file_mtime, "data": data}
+        self.save_tags_cache()
+        return data
+
+    def get_tags_raw(self, fname, rel_fname):
+        lang = filename_to_lang(fname)
+        if not lang:
+            return
+
+        language = get_language(lang)
+        parser = get_parser(lang)
+
+        # Load the tags queries
+        try:
+            scm_fname = os.path.join("aiderrepomap", "queries", f"tree-sitter-{lang}-tags.scm")
+        except KeyError:
+            return
+        query_scm = Path(scm_fname)
+        if not query_scm.exists():
+            return
+        query_scm = query_scm.read_text()
+
+        code = self.io.read_text(fname)
+        if not code:
+            return
+        tree = parser.parse(bytes(code, "utf-8"))
+
+        # Run the tags queries
+        query = language.query(query_scm)
+        captures = query.captures(tree.root_node)
+
+        captures = list(captures)
+
+        saw = set()
+        for node, tag in captures:
+            if tag.startswith("name.definition."):
+                kind = "def"
+            elif tag.startswith("name.reference."):
+                kind = "ref"
+            else:
+                continue
+
+            saw.add(kind)
+
+            result = Tag(
+                rel_fname=rel_fname,
+                fname=fname,
+                name=node.text.decode("utf-8"),
+                kind=kind,
+                line=node.start_point[0],
+            )
+
+            yield result
+
+        if "ref" in saw:
+            return
+        if "def" not in saw:
+            return
+
+        # We saw defs, without any refs
+        # Some tags files only provide defs (cpp, for example)
+        # Use pygments to backfill refs
+
+        try:
+            lexer = guess_lexer_for_filename(fname, code)
+        except ClassNotFound:
+            return
+
+        tokens = list(lexer.get_tokens(code))
+        tokens = [token[1] for token in tokens if token[0] in Token.Name]
+
+        for token in tokens:
+            yield Tag(
+                rel_fname=rel_fname,
+                fname=fname,
+                name=token,
+                kind="ref",
+                line=-1,
+            )
+
+    def get_ranked_tags(self, chat_fnames, other_fnames):
+        defines = defaultdict(set)
+        references = defaultdict(list)
+        definitions = defaultdict(set)
+
+        personalization = dict()
+
+        fnames = set(chat_fnames).union(set(other_fnames))
+        chat_rel_fnames = set()
+
+        fnames = sorted(fnames)
+
+        if self.cache_missing:
+            fnames = tqdm(fnames)
+        self.cache_missing = False
+
+        for fname in fnames:
+            if not Path(fname).is_file():
+                if fname not in self.warned_files:
+                    if Path(fname).exists():
+                        self.io.tool_error(
+                            f"Repo-map can't include {fname}, it is not a normal file"
+                        )
+                    else:
+                        self.io.tool_error(f"Repo-map can't include {fname}, it no longer exists")
+
+                self.warned_files.add(fname)
+                continue
+
+            # dump(fname)
+            rel_fname = self.get_rel_fname(fname)
+
+            if fname in chat_fnames:
+                personalization[rel_fname] = 1.0
+                chat_rel_fnames.add(rel_fname)
+
+            tags = list(self.get_tags(fname, rel_fname))
+            if tags is None:
+                continue
+
+            for tag in tags:
+                if tag.kind == "def":
+                    defines[tag.name].add(rel_fname)
+                    key = (rel_fname, tag.name)
+                    definitions[key].add(tag)
+
+                if tag.kind == "ref":
+                    references[tag.name].append(rel_fname)
+
+        ##
+        # dump(defines)
+        # dump(references)
+
+        if not references:
+            references = dict((k, list(v)) for k, v in defines.items())
+
+        idents = set(defines.keys()).intersection(set(references.keys()))
+
+        G = nx.MultiDiGraph()
+
+        for ident in idents:
+            definers = defines[ident]
+            for referencer, num_refs in Counter(references[ident]).items():
+                for definer in definers:
+                    # if referencer == definer:
+                    #    continue
+                    G.add_edge(referencer, definer, weight=num_refs, ident=ident)
+
+        if not references:
+            pass
+
+        if personalization:
+            pers_args = dict(personalization=personalization, dangling=personalization)
+        else:
+            pers_args = dict()
+
+        try:
+            ranked = nx.pagerank(G, weight="weight", **pers_args)
+        except ZeroDivisionError:
+            return []
+
+        # distribute the rank from each source node, across all of its out edges
+        ranked_definitions = defaultdict(float)
+        for src in G.nodes:
+            src_rank = ranked[src]
+            total_weight = sum(data["weight"] for _src, _dst, data in G.out_edges(src, data=True))
+            # dump(src, src_rank, total_weight)
+            for _src, dst, data in G.out_edges(src, data=True):
+                data["rank"] = src_rank * data["weight"] / total_weight
+                ident = data["ident"]
+                ranked_definitions[(dst, ident)] += data["rank"]
+
+        ranked_tags = []
+        ranked_definitions = sorted(ranked_definitions.items(), reverse=True, key=lambda x: x[1])
+
+        # dump(ranked_definitions)
+
+        for (fname, ident), rank in ranked_definitions:
+            # print(f"{rank:.03f} {fname} {ident}")
+            if fname in chat_rel_fnames:
+                continue
+            ranked_tags += list(definitions.get((fname, ident), []))
+
+        rel_other_fnames_without_tags = set(self.get_rel_fname(fname) for fname in other_fnames)
+
+        fnames_already_included = set(rt[0] for rt in ranked_tags)
+
+        top_rank = sorted([(rank, node) for (node, rank) in ranked.items()], reverse=True)
+        for rank, fname in top_rank:
+            if fname in rel_other_fnames_without_tags:
+                rel_other_fnames_without_tags.remove(fname)
+            if fname not in fnames_already_included:
+                ranked_tags.append((fname,))
+
+        for fname in rel_other_fnames_without_tags:
+            ranked_tags.append((fname,))
+
+        return ranked_tags
+
+    def get_ranked_tags_map(self, chat_fnames, other_fnames=None):
+        if not other_fnames:
+            other_fnames = list()
+
+        ranked_tags = self.get_ranked_tags(chat_fnames, other_fnames)
+        num_tags = len(ranked_tags)
+
+        lower_bound = 0
+        upper_bound = num_tags
+        best_tree = None
+
+        chat_rel_fnames = [self.get_rel_fname(fname) for fname in chat_fnames]
+
+        while lower_bound <= upper_bound:
+            middle = (lower_bound + upper_bound) // 2
+            tree = self.to_tree(ranked_tags[:middle], chat_rel_fnames)
+            num_tokens = self.token_count(tree)
+
+            if num_tokens < self.max_map_tokens:
+                best_tree = tree
+                lower_bound = middle + 1
+            else:
+                upper_bound = middle - 1
+
+        return best_tree
+
+    def to_tree(self, tags, chat_rel_fnames):
+        if not tags:
+            return ""
+
+        tags = [tag for tag in tags if tag[0] not in chat_rel_fnames]
+        tags = sorted(tags)
+
+        cur_fname = None
+        context = None
+        output = ""
+
+        # add a bogus tag at the end so we trip the this_fname != cur_fname...
+        dummy_tag = (None,)
+        for tag in tags + [dummy_tag]:
+            this_rel_fname = tag[0]
+
+            # ... here ... to output the final real entry in the list
+            if this_rel_fname != cur_fname:
+                if context:
+                    context.add_context()
+                    output += "\n"
+                    output += cur_fname + ":\n"
+                    output += context.format()
+                    context = None
+                elif cur_fname:
+                    output += "\n" + cur_fname + "\n"
+
+                if type(tag) is Tag:
+                    code = self.io.read_text(tag.fname) or ""
+
+                    context = TreeContext(
+                        tag.rel_fname,
+                        code,
+                        color=False,
+                        line_number=False,
+                        child_context=False,
+                        last_line=False,
+                        margin=0,
+                        mark_lois=False,
+                        loi_pad=0,
+                        # header_max=30,
+                        show_top_of_file_parent_scope=False,
+                    )
+                cur_fname = this_rel_fname
+
+            if context:
+                context.add_lines_of_interest([tag.line])
+
+        return output
+
+    def get_inchat_relative_files(self, abs_fnames):
+        files = [self.get_rel_fname(fname) for fname in abs_fnames]
+        return sorted(set(files))
+
+    def get_all_relative_files(self):
+        files = self.repo.get_tracked_files()
+        files = [fname for fname in files if Path(self.abs_root_path(fname)).is_file()]
+        return sorted(set(files))
+
+    def get_all_abs_files(self):
+        files = self.get_all_relative_files()
+        files = [self.abs_root_path(path) for path in files]
+        return files
+
+    def abs_root_path(self, path):
+        res = Path(self.root) / path
+        return utils.safe_abs_path(res)
+
+    def get_repo_map(self, abs_fnames=None):
+        if abs_fnames is None:
+            abs_fnames = []
+        other_files = set(self.get_all_abs_files()) - set(abs_fnames)
+        repo_content = self.get_repo_map_of_files(abs_fnames, other_files)
+        return repo_content
+
+    def get_repo_ranked_tags_map(self, abs_fnames):
+        other_files = set(self.get_all_abs_files()) - set(abs_fnames)
+        repo_content = self.get_ranked_tags_map(abs_fnames, other_files)
+        return repo_content
+
+
+def find_src_files(directory):
+    if not os.path.isdir(directory):
+        return [directory]
+
+    src_files = []
+    for root, dirs, files in os.walk(directory):
+        for file in files:
+            src_files.append(os.path.join(root, file))
+    return src_files

--- a/aiderrepomap/utils.py
+++ b/aiderrepomap/utils.py
@@ -1,0 +1,119 @@
+import os
+import tempfile
+from pathlib import Path
+
+import git
+
+from aiderrepomap.dump import dump  # noqa: F401
+
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp"}
+
+
+class IgnorantTemporaryDirectory:
+    def __init__(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+    def __enter__(self):
+        return self.temp_dir.__enter__()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        try:
+            self.temp_dir.__exit__(exc_type, exc_val, exc_tb)
+        except (OSError, PermissionError):
+            pass  # Ignore errors (Windows)
+
+
+class ChdirTemporaryDirectory(IgnorantTemporaryDirectory):
+    def __init__(self):
+        try:
+            self.cwd = os.getcwd()
+        except FileNotFoundError:
+            self.cwd = None
+
+        super().__init__()
+
+    def __enter__(self):
+        res = super().__enter__()
+        os.chdir(self.temp_dir.name)
+        return res
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.cwd:
+            try:
+                os.chdir(self.cwd)
+            except FileNotFoundError:
+                pass
+        super().__exit__(exc_type, exc_val, exc_tb)
+
+
+class GitTemporaryDirectory(ChdirTemporaryDirectory):
+    def __enter__(self):
+        dname = super().__enter__()
+        self.repo = make_repo(dname)
+        return dname
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        del self.repo
+        super().__exit__(exc_type, exc_val, exc_tb)
+
+
+def make_repo(path=None):
+    if not path:
+        path = "."
+    repo = git.Repo.init(path)
+    repo.config_writer().set_value("user", "name", "Test User").release()
+    repo.config_writer().set_value("user", "email", "testuser@example.com").release()
+
+    return repo
+
+
+def is_image_file(file_name):
+    """
+    Check if the given file name has an image file extension.
+
+    :param file_name: The name of the file to check.
+    :return: True if the file is an image, False otherwise.
+    """
+    file_name = str(file_name)  # Convert file_name to string
+    return any(file_name.endswith(ext) for ext in IMAGE_EXTENSIONS)
+
+
+def safe_abs_path(res):
+    "Gives an abs path, which safely returns a full (not 8.3) windows path"
+    res = Path(res).resolve()
+    return str(res)
+
+
+def show_messages(messages, title=None, functions=None):
+    if title:
+        print(title.upper(), "*" * 50)
+
+    for msg in messages:
+        role = msg["role"].upper()
+        content = msg.get("content")
+        if isinstance(content, list):  # Handle list content (e.g., image messages)
+            for item in content:
+                if isinstance(item, dict) and "image_url" in item:
+                    print(role, "Image URL:", item["image_url"]["url"])
+        elif isinstance(content, str):  # Handle string content
+            for line in content.splitlines():
+                print(role, line)
+        content = msg.get("function_call")
+        if content:
+            print(role, content)
+
+    if functions:
+        dump(functions)
+
+
+def is_gpt4_with_openai_base_url(model_name, client):
+    """
+    Check if the model_name starts with 'gpt-4' and the client base URL includes 'api.openai.com'.
+
+    :param model_name: The name of the model to check.
+    :param client: The OpenAI client instance.
+    :return: True if conditions are met, False otherwise.
+    """
+    if client is None or not hasattr(client, "base_url"):
+        return False
+    return model_name.startswith("gpt-4") and "api.openai.com" in client.base_url.host

--- a/config/default_with_repomap.yaml
+++ b/config/default_with_repomap.yaml
@@ -1,0 +1,113 @@
+system_template: |-
+  SETTING: You are an autonomous programmer, and you're working directly in the command line with a special interface.
+
+  The special interface consists of a file editor that shows you {WINDOW} lines of a file at a time.
+  In addition to typical bash commands, you can also use the following commands to help you navigate and edit files.
+
+  COMMANDS:
+  {command_docs}
+
+  Please note that THE EDIT COMMAND REQUIRES PROPER INDENTATION. 
+  If you'd like to add the line '        print(x)' you must fully write that out, with all those spaces before the code! Indentation is important and code that is not indented correctly will fail and require fixing before it can be run.
+
+  RESPONSE FORMAT:
+  Your shell prompt is formatted as follows:
+  (Open file: <path>) <cwd> $
+
+  You need to format your output using two fields; discussion and command.
+  Your output should always include _one_ discussion and _one_ command field EXACTLY as in the following example:
+  DISCUSSION
+  First I'll start by using ls to see what files are in the current directory. Then maybe we can look at some relevant files to see what they look like.
+  ```
+  ls -a
+  ```
+
+  You should only include a *SINGLE* command in the command section and then wait for a response from the shell before continuing with more discussion and commands. Everything you include in the DISCUSSION section will be saved for future reference.
+  If you'd like to issue two commands at once, PLEASE DO NOT DO THAT! Please instead first submit just the first command, and then after receiving a response you'll be able to issue the second command. 
+  You're free to use any other bash commands you want (e.g. find, grep, cat, ls, cd) in addition to the special commands listed above.
+  However, the environment does NOT support interactive session commands (e.g. python, vim), so please do not invoke them.
+instance_template: |-
+  Here is a map of our repository showing files and signatures in code files:
+  {repo_map}
+  
+  We're currently solving the following issue within our repository. Here's the issue text:
+  ISSUE:
+  {issue}
+
+  INSTRUCTIONS:
+  Now, you're going to solve this issue on your own. Your terminal session has started and you're in the repository's root directory. You can use any bash commands or the special interface to help you. Edit all the files you need to and run any checks or tests that you want. 
+  Remember, YOU CAN ONLY ENTER ONE COMMAND AT A TIME. You should always wait for feedback after every command. 
+  When you're satisfied with all of the changes you've made, you can submit your changes to the code base by simply running the submit command.
+  Note however that you cannot use any interactive session commands (e.g. python, vim) in this environment, but you can write scripts and run them. E.g. you can write a python script and then run it with `python <script_name>.py`.
+  
+  NOTE ABOUT THE EDIT COMMAND: Indentation really matters! When editing a file, make sure to insert appropriate indentation before each line! 
+
+  IMPORTANT TIPS:
+  1. Always start by trying to replicate the bug that the issues discusses. 
+     If the issue includes code for reproducing the bug, we recommend that you re-implement that in your environment, and run it to make sure you can reproduce the bug.
+     Then start trying to fix it.
+     When you think you've fixed the bug, re-run the bug reproduction script to make sure that the bug has indeed been fixed.
+     
+     If the bug reproduction script does not print anything when it succesfully runs, we recommend adding a print("Script completed successfully, no errors.") command at the end of the file,
+     so that you can be sure that the script indeed ran fine all the way through. 
+
+  2. If you run a command and it doesn't work, try running a different command. A command that did not work once will not work the second time unless you modify it!
+
+  3. If you open a file and need to get to an area around a specific line that is not in the first 100 lines, say line 583, don't just use the scroll_down command multiple times. Instead, use the goto 583 command. It's much quicker. 
+     
+  4. If the bug reproduction script requires inputting/reading a specific file, such as buggy-input.png, and you'd like to understand how to input that file, conduct a search in the existing repo code, to see whether someone else has already done that. Do this by running the command: find_file "buggy-input.png" If that doensn't work, use the linux 'find' command. 
+
+  5. Always make sure to look at the currently open file and the current working directory (which appears right after the currently open file). The currently open file might be in a different directory than the working directory! Note that some commands, such as 'create', open files, so they might change the current  open file.
+
+  6. When editing files, it is easy to accidentally specify a wrong line number or to write code with incorrect indentation. Always check the code after you issue an edit to make sure that it reflects what you wanted to accomplish. If it didn't, issue another command to fix it.
+     
+
+  (Open file: {open_file})
+  (Current directory: {working_dir})
+  bash-$
+next_step_template: |-
+  {observation}
+  (Open file: {open_file})
+  (Current directory: {working_dir})
+  bash-$
+next_step_no_output_template: |-
+  Your command ran successfully and did not produce any output.
+  (Open file: {open_file})
+  (Current directory: {working_dir})
+  bash-$
+demonstration_template: |
+  Here is a demonstration of how to correctly accomplish this task.
+  It is included to show you how to correctly use the interface.
+  You do not need to follow exactly what is done in the demonstration.
+  --- DEMONSTRATION ---
+  {demonstration}
+  --- END OF DEMONSTRATION ---
+state_command:
+  name: state
+  code: |
+    state() {
+      local working_dir="$PWD";
+      if [ -z $CURRENT_FILE ]; then
+          echo '{"open_file": "n/a", "working_dir": "'$working_dir'"}';
+      else
+          echo '{"open_file": "'$(realpath $CURRENT_FILE)'", "working_dir": "'$working_dir'"}';
+      fi
+    };
+parse_function: ThoughtActionParser
+env_variables:
+  WINDOW: 100
+  OVERLAP: 2
+  CURRENT_LINE: 0
+  CURRENT_FILE: ''
+  SEARCH_RESULTS: ()
+  SEARCH_FILES: ()
+  SEARCH_INDEX: 0
+command_files:
+- config/commands/defaults.sh
+- config/commands/search.sh
+- config/commands/edit_linting.sh
+- config/commands/_split_string.py
+parse_command: ParseCommandDetailed
+history_processor: DefaultHistoryProcessor
+demonstrations:
+- trajectories/demonstrations/replay__marshmallow-code__marshmallow-1867__default_sys-env_window100__t-0.20__p-0.95__c-2.00__install-1/marshmallow-code__marshmallow-1867.traj

--- a/config/default_with_repomap.yaml
+++ b/config/default_with_repomap.yaml
@@ -27,7 +27,7 @@ system_template: |-
   You're free to use any other bash commands you want (e.g. find, grep, cat, ls, cd) in addition to the special commands listed above.
   However, the environment does NOT support interactive session commands (e.g. python, vim), so please do not invoke them.
 instance_template: |-
-  Here is a map of our repository showing files and signatures in code files:
+  Here is a map of your working directory's latest state, showing files and signatures in code files:
   {repo_map}
   
   We're currently solving the following issue within our repository. Here's the issue text:

--- a/config/default_with_repomap.yaml
+++ b/config/default_with_repomap.yaml
@@ -93,7 +93,7 @@ state_command:
           echo '{"open_file": "'$(realpath $CURRENT_FILE)'", "working_dir": "'$working_dir'"}';
       fi
     };
-parse_function: ThoughtActionParser
+parse_function: ThoughtActionGreedyParser
 env_variables:
   WINDOW: 100
   OVERLAP: 2


### PR DESCRIPTION
I've been experimenting with the SWE-Agent and made some improvements on the go that I thought would be worth considering adding to the project

# What does this implement?

- Repo map implementation from [Aider](https://github.com/paul-gauthier/aider)
- Google Vertex AI integration
- A greedy thought-action parser to handle files that contain triple backticks (```)

## Repo map

When using the agent on an existing codebase I encountered the issue where the agent starts to reimplement existing code, to give the LLM context for avoiding this I have added the repo map code from [Aider](https://github.com/paul-gauthier/aider)
The Repo map feature adds a snippet like this to the first user message
```
Here is a map of your working directory's latest state, showing files and signatures in code files:

.gitignore

readme.md

requirements.txt

sonoff_diy_api/smart_socket_mock.py:
│class SmartSocketMock:
│    def __init__(self):
│        # Initialize device state and attributes
│        self.switch_state = "off"  # Initial state of the switch
│        self.startup_state = "stay"  # Power on state
│        self.signal_strength = -70  # WiFi signal strength
│        self.pulse_state = "off"  # Inching state
│        self.pulse_width = 500  # Inching pulse width
│        self.ssid = "sonoffDiy"  # WiFi SSID
│        self.password = "20170618sn"  # WiFi password
⋮...
│    def switch(self, switch_state):
⋮...
│    def startup(self, startup_state):
⋮...
│    def signal_strength(self):
⋮...
│    def pulse(self, pulse_state, pulse_width=None):
⋮...
│    def wifi(self, ssid, password):
⋮...
│    def ota_unlock(self):
⋮...
│    def ota_flash(self, download_url, sha256sum):
⋮...
│    def info(self):
⋮...
```


## Google Vertex AI integration

Added a Vertex AI integration for access to 1M context window models

## Greedy parser

When the agent tried to write documentation in markdown files I encountered the issue of the action parser failing to read file with triple backtick (```) blocks. To fix this I added the ThoughtActionGreedyParser class that parses the string between the outer backticks as the only action, as multiple action outputs seem to be unsupported. I know that a workaround would be using an xml-agent, but that might be too complex syntax for smaller LLMs

# Any other comments?

I hope any of these features would be of use. Let me know if you would like me to cherry-pick and polish any of them to a separate PR

I have not had the time to write tests and make sure these features smoothly integrate with everything else

🧡 Thanks for contributing!
