### PR TITLE
Docs: Add search

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
 
 plugins:
    - glightbox
+   - search
 
 repo_url: https://github.com/princeton-nlp/SWE-agent
 repo_name: princeton-nlp/SWE-agent


### PR DESCRIPTION
Closes #387

Search is added by default but must be manually added if any other plugins are
configured

See https://github.com/squidfunk/mkdocs-material/blob/master/docs/setup/setting-up-site-search.md
