### PR TITLE
Issue #328: Auto-scrolling in web-UI Update

### DIFF
--- a/sweagent/frontend/src/Run.js
+++ b/sweagent/frontend/src/Run.js
@@ -208,7 +208,6 @@ function Run() {
           },
         ]);
         if (envFeedRef.current) {
-          console.log("checking env");
           setTimeout(() => {
             scrollEnv();
           }, 100);
@@ -225,7 +224,6 @@ function Run() {
         ]);
         if (agentFeedRef.current) {
           setTimeout(() => {
-            console.log("checking agent");
             scrollAgent();
           }, 100);
         }

--- a/sweagent/frontend/src/Run.js
+++ b/sweagent/frontend/src/Run.js
@@ -169,7 +169,8 @@ function Run() {
     }
   };
 
-  const scrollDetected = () => checkScrollPosition(logsRef, isLogScrolled, 58);
+  const scrollDetectedLog = () =>
+    checkScrollPosition(logsRef, isLogScrolled, 58);
   const scrollLog = () => scrollToBottom(logsRef, isLogScrolled);
 
   const scrollDetectedEnv = () =>
@@ -182,15 +183,12 @@ function Run() {
 
   // Use effect to listen to socket updates
   React.useEffect(() => {
-    logsRef.current.removeEventListener("scroll", scrollDetected);
-    logsRef.current.addEventListener("scroll", scrollDetected, {
+    logsRef.current.addEventListener("scroll", scrollDetectedLog, {
       passive: true,
     });
-    envFeedRef.current.removeEventListener("scroll", scrollDetectedEnv);
     envFeedRef.current.addEventListener("scroll", scrollDetectedEnv, {
       passive: true,
     });
-    agentFeedRef.current.removeEventListener("scroll", scrollDetectedAgent);
     agentFeedRef.current.addEventListener("scroll", scrollDetectedAgent, {
       passive: true,
     });
@@ -229,7 +227,7 @@ function Run() {
         }
       }
       return () => {
-        logsRef.current.removeEventListener("scroll", scrollDetected);
+        logsRef.current.removeEventListener("scroll", scrollDetectedLog);
         envFeedRef.current.removeEventListener("scroll", scrollDetectedEnv);
         agentFeedRef.current.removeEventListener("scroll", scrollDetectedAgent);
       };

--- a/sweagent/frontend/src/components/panels/AgentFeed.js
+++ b/sweagent/frontend/src/components/panels/AgentFeed.js
@@ -4,14 +4,6 @@ import MacBar from "../MacBar";
 import editorLogo from "../../assets/panel_icons/editor.png";
 import "../../static/agentFeed.css";
 
-function useScrollToBottom(feed, ref) {
-  useEffect(() => {
-    if (ref.current) {
-      ref.current.scrollTop = ref.current.scrollHeight;
-    }
-  }, [feed, ref]);
-}
-
 const AgentFeed = ({
   feed,
   highlightedStep,
@@ -19,8 +11,6 @@ const AgentFeed = ({
   handleMouseLeave,
   selfRef,
 }) => {
-  useScrollToBottom(feed, selfRef);
-
   return (
     <div id="agentFeed" className="agentFeed">
       <MacBar title="Thoughts" logo={editorLogo} />

--- a/sweagent/frontend/src/components/panels/EnvFeed.js
+++ b/sweagent/frontend/src/components/panels/EnvFeed.js
@@ -5,14 +5,6 @@ import MacBar from "../MacBar";
 import terminalLogo from "../../assets/panel_icons/terminal.png";
 import "../../static/envFeed.css";
 
-function useScrollToBottom(feed, ref) {
-  useEffect(() => {
-    if (ref.current) {
-      ref.current.scrollTop = ref.current.scrollHeight;
-    }
-  }, [feed, ref]);
-}
-
 const EnvFeed = ({
   feed,
   highlightedStep,
@@ -20,8 +12,6 @@ const EnvFeed = ({
   handleMouseLeave,
   selfRef,
 }) => {
-  useScrollToBottom(feed, selfRef);
-
   return (
     <div id="envFeed" className="envFeed">
       <MacBar title="Terminal" logo={terminalLogo} dark={false} />


### PR DESCRIPTION
Issue #328: 
- "Every time a new message appears in one of the feeds/logs of the web UI, we scroll to the bottom. However, if a user wants to read a certain part during the run and has scrolled up, we shouldn't scroll down."

Solution: 
- Implemented useRef's to track whether a user has scrolled in either EnvFeed, AgentFeed, or LogPanel. If a user has scrolled, at each update per feed/panel, do not auto-scroll. Otherwise, if a user has not scrolled or has scrolled to the bottom, at each update per feed/panel, continue to auto-scroll.
- Removed basic scrolldown feature from EnvFeed.js, AgentFeed.js, and Run.js for redundancy.