### PR TITLE
Resolve relative paths to demonstrations and commands

### DIFF
--- a/docs/config/config.md
+++ b/docs/config/config.md
@@ -71,6 +71,10 @@ In the [`config/`](https://github.com/princeton-nlp/SWE-agent/tree/main/config) 
 * [`configs/`](https://github.com/princeton-nlp/SWE-agent/tree/main/config/configs) for examples of properly formatted configuration files. Each configuration differs in its set of commands, input/output format, demonstrations, etc.
 * [`commands/`](https://github.com/princeton-nlp/SWE-agent/tree/main/config/commands) for the bash implementations of the custom commands that SWE-agent uses to navigate + edit the codebase. More information [here](commands.md).
 
+!!! hint "Relative paths"
+    Relative paths in config files are resolved to the `SWE_AGENT_CONFIG_ROOT` environment variable (if set)
+    or the SWE-agent repository root.
+
 ## How a Configuration File is Processed
 Some notes on processing that occurs on config fields when SWE-agent is run:
 

--- a/docs/config/env.md
+++ b/docs/config/env.md
@@ -1,0 +1,9 @@
+# Environment variables
+
+This page details all environment variables that are currently in use by SWE-agent.
+
+* All API keys (for LMs and GitHub) can be set as an environment variable. See [here](../installation/keys.md) for more information.
+* [Experimental] `SWE_AGENT_EXPERIMENTAL_COMMUNICATE` switches to a faster way of communicating with running docker
+  shell sessions. This has not been tested on SWE-bench, so it might sometimes break.
+  However, it can be very useful when running on single issues.
+* `SWE_AGENT_CONFIG_ROOT`: Used to resolve relative paths in the [config](config.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
     - "Config files": "config/config.md"
     - "Command definitions": "config/commands.md"
     - "Demonstrations": "config/demonstrations.md"
+    - "Environment variables": "config/env.md"
   - Development:
     - "Contribution guide": "dev/contribute.md"
     - "Code structure": "dev/code_structure.md"

--- a/run.py
+++ b/run.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from sweagent import CONFIG_DIR
+
 try:
     import rich
 except ModuleNotFoundError as e:
@@ -475,7 +477,7 @@ def get_args(args=None) -> ScriptArguments:
                 temperature=0.0,
                 top_p=0.95,
             ),
-            config_file=Path("config/default.yaml"),
+            config_file=CONFIG_DIR / "default.yaml",
         ),
         actions=ActionsArguments(open_pr=False, skip_if_commits_reference_issue=True),
     )

--- a/sweagent/__init__.py
+++ b/sweagent/__init__.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 PACKAGE_DIR = Path(__file__).resolve().parent
 assert PACKAGE_DIR.is_dir()
+REPO_ROOT = PACKAGE_DIR.parent
+assert REPO_ROOT.is_dir()
 CONFIG_DIR = PACKAGE_DIR.parent / "config"
 assert CONFIG_DIR.is_dir()
 

--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -52,13 +52,13 @@ class AgentConfig(FrozenSerializable):
     strategy_template: str | None = None
     demonstration_template: str | None = None
     # Paths to demonstrations. If path is not absolute, it is assumed to be
-    # relative the repository root.
+    # relative to the SWE_AGENT_CONFIG_ROOT (if set) or the SWE-agent repository root
     demonstrations: list[str | Path] = field(default_factory=list)
     put_demos_in_history: bool = False  # if True, add demonstration to history instead of as a single message
     # defaults to format_error_template in ParseFunction
     format_error_template: str = None  # type: ignore
     # Paths to command files. If path is not absolute, it is assumed to be
-    # relative the repository root.
+    # relative to the SWE_AGENT_CONFIG_ROOT (if set) or the SWE-agent repository root
     command_files: list[str | Path] = field(default_factory=list)
     env_variables: dict[str, str] = field(default_factory=dict)
     util_functions: list[str] = field(default_factory=list)

--- a/sweagent/agent/commands.py
+++ b/sweagent/agent/commands.py
@@ -81,7 +81,7 @@ class ParseCommandBash(ParseCommand):
         if contents.strip().startswith("#!"):
             commands = self.parse_script(path, contents)
         else:
-            if not path.endswith(".sh") and not Path(path).name.startswith("_"):
+            if Path(path).suffix != ".sh" and not Path(path).name.startswith("_"):
                 msg = (
                     f"Source file {path} does not have a .sh extension.\n"
                     "Only .sh files are supported for bash function parsing.\n"

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -21,6 +21,7 @@ from simple_parsing.helpers.serialization.serializable import FrozenSerializable
 from swebench import MAP_VERSION_TO_INSTALL, get_environment_yml, get_requirements
 
 import docker
+from sweagent import REPO_ROOT
 from sweagent.environment.utils import (
     LOGGER_NAME,
     PROCESS_DONE_MARKER_END,
@@ -111,7 +112,7 @@ class SWEEnv(gym.Env):
         #: The commit hash of the swe-agent repository
         self.commit_sha = None
         try:
-            repo = Repo(search_parent_directories=True)
+            repo = Repo(REPO_ROOT, search_parent_directories=True)
             self.commit_sha = repo.head.object.hexsha
         except KeyboardInterrupt:
             raise

--- a/sweagent/utils/config.py
+++ b/sweagent/utils/config.py
@@ -13,10 +13,14 @@ logger = logging.getLogger("config")
 
 def convert_path_to_abspath(path: Path | str) -> Path:
     """If path is not absolute, convert it to an absolute path
-    using REPO_ROOT as base."""
+    using the SWE_AGENT_CONFIG_ROOT environment variable (if set) or
+    REPO_ROOT as base.
+    """
     path = Path(path)
+    root = Path(os.environ.get("SWE_AGENT_CONFIG_ROOT", REPO_ROOT))
+    assert root.is_dir()
     if not path.is_absolute():
-        path = REPO_ROOT / path
+        path = root / path
     assert path.is_absolute()
     return path.resolve()
 

--- a/sweagent/utils/config.py
+++ b/sweagent/utils/config.py
@@ -6,8 +6,23 @@ from pathlib import Path
 from typing import Any
 
 import config as config_file
+from sweagent import REPO_ROOT
 
 logger = logging.getLogger("config")
+
+
+def convert_path_to_abspath(path: Path | str) -> Path:
+    """If path is not absolute, convert it to an absolute path
+    using REPO_ROOT as base."""
+    path = Path(path)
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+    assert path.is_absolute()
+    return path.resolve()
+
+
+def convert_paths_to_abspath(paths: list[Path | str]) -> list[Path]:
+    return [convert_path_to_abspath(p) for p in paths]
 
 
 class Config:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest import mock
 
 import pytest
 
-from sweagent.utils.config import Config
+from sweagent import REPO_ROOT
+from sweagent.utils.config import Config, convert_path_to_abspath, convert_paths_to_abspath
 
 
 def test_config_retrieval_fails():
@@ -31,3 +33,12 @@ def test_retrieve_from_env(tmp_path):
         tmp_keys_cfg.write_text("MY_KEY: 'other VALUE'\n")
         config = Config(keys_cfg_path=tmp_keys_cfg)
         assert config["MY_KEY"] == "VALUE"
+
+
+def test_convert_path_to_abspath():
+    assert convert_path_to_abspath("sadf") == REPO_ROOT / "sadf"
+    assert convert_path_to_abspath("/sadf") == Path("/sadf")
+
+
+def test_convert_paths_to_abspath():
+    assert convert_paths_to_abspath([Path("sadf"), "/sadf"]) == [REPO_ROOT / "sadf", Path("/sadf")]


### PR DESCRIPTION
This PR should allow to run `run.py` from another directory. This is a preparation for making it available as a python package.

Closes #225
