### PR TITLE
Issue #446: Fixed calls to open without ctx manager

### DIFF
--- a/evaluation/aggregate_results.py
+++ b/evaluation/aggregate_results.py
@@ -123,7 +123,8 @@ def convert_experiments_to_rows(folder_name, runs_max):
             costs_success = []
             costs_failure = []
             for x in glob.glob(os.path.join(str(folder), "*.traj")):
-                traj_data = json.load(open(x))
+                with open(x) as file:
+                    traj_data = json.load(file)
                 if "model_stats" not in traj_data["info"]:
                     continue
                 run_cost = traj_data["info"]["model_stats"]["instance_cost"]

--- a/evaluation/evaluation.py
+++ b/evaluation/evaluation.py
@@ -5,6 +5,7 @@ import json
 import os
 import traceback
 from collections import Counter
+from pathlib import Path
 
 from rich import print
 from swebench import (
@@ -52,7 +53,7 @@ def main(
 
     pred_total, pred_will_eval = 0, 0
     with open(pred_path_temp, "w") as f:
-        for l in open(pred_path_orig).readlines():
+        for l in Path(pred_path_orig).read_text().splitlines(keepends=True):
             pred_total += 1
             p = json.loads(l)
             # Exclude predictions w/ empty strings
@@ -88,7 +89,7 @@ def main(
     os.remove(pred_path_temp)
 
     # Get predictions, define log_dir
-    predictions = [json.loads(l) for l in open(pred_path_orig).readlines()]
+    predictions = [json.loads(l) for l in Path(pred_path_orig).read_text().splitlines()]
     log_dir = os.path.join(log_dir, directory_name)
     print(f"Log directory for evaluation run: {log_dir}")
 
@@ -100,7 +101,8 @@ def main(
         # Add trajectory statistics if traj_path exists
         traj_path = os.path.join(directory, f"{p[KEY_INSTANCE_ID]}.traj")
         if os.path.exists(traj_path):
-            traj_data = json.load(open(traj_path))
+            with open(traj_path) as f:
+                traj_data = json.load(f)
             scorecard["stats"]["traj_num_steps"] = len(traj_data["trajectory"])
             scorecard["stats"]["traj_action_dist"] = dict(
                 Counter(

--- a/inspector/server.py
+++ b/inspector/server.py
@@ -277,7 +277,7 @@ def main(data_path, directory, port):
     data = []
     if data_path is not None:
         if data_path.endswith(".jsonl"):
-            data = [json.loads(x) for x in Path(data_path).read_text().splitlines(keepend=True)]
+            data = [json.loads(x) for x in Path(data_path).read_text().splitlines(keepends=True)]
         elif data_path.endswith(".json"):
             with open(data_path) as f:
                 data = json.load(f)

--- a/inspector/server.py
+++ b/inspector/server.py
@@ -277,15 +277,18 @@ def main(data_path, directory, port):
     data = []
     if data_path is not None:
         if data_path.endswith(".jsonl"):
-            data = [json.loads(x) for x in open(data_path).readlines()]
+            data = [json.loads(x) for x in Path(data_path).read_text().splitlines(keepend=True)]
         elif data_path.endswith(".json"):
-            data = json.load(open(data_path))
+            with open(data_path) as f:
+                data = json.load(f)
     elif "args.yaml" in os.listdir(directory):
-        args = yaml.safe_load(open(os.path.join(directory, "args.yaml")))
+        with open(os.path.join(directory, "args.yaml")) as file:
+            args = yaml.safe_load(file)
         if "environment" in args and "data_path" in args["environment"]:
             data_path = os.path.join(Path(__file__).parent, "..", args["environment"]["data_path"])
             if os.path.exists(data_path):
-                data = json.load(open(data_path))
+                with open(data_path) as f:
+                    data = json.load(f)
 
     gold_patches = {d["instance_id"]: d["patch"] if "patch" in d else None for d in data}
     test_patches = {d["instance_id"]: d["test_patch"] if "test_patch" in d else None for d in data}

--- a/inspector/static.py
+++ b/inspector/static.py
@@ -97,11 +97,12 @@ def save_static_viewer(file_path):
         file_path = Path(file_path)
     data = []
     if "args.yaml" in list(map(lambda x: x.name, file_path.parent.iterdir())):
-        args = yaml.safe_load(open(file_path.parent / "args.yaml"))
+        args = yaml.safe_load(Path(file_path.parent / "args.yaml").read_text())
         if "environment" in args and "data_path" in args["environment"]:
             data_path = Path(__file__).parent.parent / args["environment"]["data_path"]
             if data_path.exists():
-                data = json.load(open(data_path))
+                with open(data_path) as f:
+                    data = json.load(f)
             if not isinstance(data, list) or not data or "patch" not in data[0] or "test_patch" not in data[0]:
                 data = []
     gold_patches = {x["instance_id"]: x["patch"] for x in data}

--- a/make_demos/convert_traj_to_demo.py
+++ b/make_demos/convert_traj_to_demo.py
@@ -58,7 +58,9 @@ def save_demo(data, file, traj_path):
 
 
 def convert_traj_to_action_demo(traj_path: str, output_file: str = None, include_user: bool = False):
-    traj = json.load(open(traj_path))
+    with open(traj_path) as file:
+        traj = json.load(file)
+
     history = traj["history"]
     action_traj = list()
     admissible_roles = {"assistant", "user"} if include_user else {"assistant"}

--- a/sweagent/agent/agents.py
+++ b/sweagent/agent/agents.py
@@ -665,7 +665,8 @@ class Agent:
         command_files = list()
         for file in self.config.command_files:
             datum = dict()
-            contents = open(file).read()
+            with open(file) as f:
+                contents = f.read()
             datum["contents"] = contents
             filename = Path(file).name
             if not contents.strip().startswith("#!"):

--- a/sweagent/agent/commands.py
+++ b/sweagent/agent/commands.py
@@ -77,7 +77,8 @@ class ParseCommand(metaclass=ParseCommandMeta):
 
 class ParseCommandBash(ParseCommand):
     def parse_command_file(self, path: str) -> list[Command]:
-        contents = open(path).read()
+        with open(path) as file:
+            contents = file.read()
         if contents.strip().startswith("#!"):
             commands = self.parse_script(path, contents)
         else:

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -808,7 +808,9 @@ class ReplayModel(BaseModel):
             msg = "--replay_path must point to a file that exists to run a replay policy"
             raise ValueError(msg)
 
-        self.replays = [list(json.loads(x).values())[0] for x in Path(self.args.replay_path).read_text().splitlines(keepends=True)]
+        self.replays = [
+            list(json.loads(x).values())[0] for x in Path(self.args.replay_path).read_text().splitlines(keepends=True)
+        ]
         self.replay_idx = 0
         self.action_idx = 0
 

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -5,6 +5,7 @@ import logging
 import os
 from collections import defaultdict
 from dataclasses import dataclass, fields
+from pathlib import Path
 
 import together
 from anthropic import AI_PROMPT, HUMAN_PROMPT, Anthropic, AnthropicBedrock
@@ -807,7 +808,7 @@ class ReplayModel(BaseModel):
             msg = "--replay_path must point to a file that exists to run a replay policy"
             raise ValueError(msg)
 
-        self.replays = [list(json.loads(x).values())[0] for x in open(self.args.replay_path).readlines()]
+        self.replays = [list(json.loads(x).values())[0] for x in Path(self.args.replay_path).read_text().splitlines(keepends=True)]
         self.replay_idx = 0
         self.action_idx = 0
 

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -698,7 +698,7 @@ class SWEEnv(gym.Env):
         if not script_path.is_file():
             msg = f"Script not found at {script_path}"
             raise FileNotFoundError(msg)
-        shell_commands = Path(script_path).read_text().splitlines()
+        shell_commands = Path(script_path).read_text().splitlines(keepends=True)
         for i, cmd in enumerate(shell_commands):
             self.communicate_with_handling(
                 cmd,

--- a/sweagent/environment/utils.py
+++ b/sweagent/environment/utils.py
@@ -701,9 +701,10 @@ def get_instances(
 
     # If file_path is a file, load the file
     if file_path.endswith(".json"):
-        return postproc_instance_list(json.load(open(file_path)))
+        with open(file_path) as file:
+            return postproc_instance_list(json.load(file))
     if file_path.endswith(".jsonl"):
-        return postproc_instance_list([json.loads(x) for x in open(file_path).readlines()])
+        return postproc_instance_list([json.loads(x) for x in Path(file_path).read_text().splitlines(keepends=True)])
 
     # Attempt load from HF datasets as a last resort
     try:


### PR DESCRIPTION

#### Reference Issues/PRs

Fixes #446 

#### What does this implement/fix? Explain your changes.
<!--
Please include a brief explanation of how your solution
fixes the tagged issue(s), along with what files / entities have
been modified for this fix.
-->
Fixes issues identified by Ruff which advises on proper file handling in Python. Replaces direct file handling methods with safer context handler by using `Path.read_text()` and `with open(...) as file:` where appropriate. 

#### Files

1. evaluation/aggregate_results.py
2. evaluation/evaluation.py
3. inspector/server.py
4. make_demos/convert_traj_to_demo.py
5. run_replay.py
6. sweagent/agent/agents.py
7. sweagent/agent/commands.py
8. sweagent/agent/models.py
9. sweagent/environment/swe_env.py
10. sweagent/environment/utils.py
11. inspector/static.py
