### PR TITLE
Doc: Add FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,16 @@
+# Frequently Asked Questions
+
+> How can I change the demonstrations given to SWE-agent?
+
+See [here](config/demonstrations.md).
+
+> Does SWE-agent run on windows?
+
+You can run it in a [docker container](installation/docker.md), though this is not our first
+choice for running SWE-agent. We're open to merge simple fixes to make the [development setup](installation/source.md)
+work.
+
+> Do you support LM X?
+
+Currently our model support is limited. SWE-agent will generally not perform well with small/cheap models.
+[More information on models](usage/usage_faq.md).

--- a/docs/usage/usage_faq.md
+++ b/docs/usage/usage_faq.md
@@ -2,6 +2,9 @@
 
 ## What models are supported?
 
+!!! note "Model support"
+    Note that SWE-agent is unlikely to perform well with small/cheap models.
+
 Models are configured in [`models.py`](https://github.com/princeton-nlp/SWE-agent/blob/main/sweagent/agent/models.py) (we're working on giving a complete list of model settings).
 
 Here are some few examples:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
     - "Models": "reference/models.md"
     - "Environment": "reference/env.md"
     - "Environment utils": "reference/env_utils.md"
+  - "FAQ": "faq.md"
 plugins:
    - glightbox
    - search


### PR DESCRIPTION
I put it at the end rather than before reference. I think it's actually easier to find that way.

@ofirpress 