### PR TITLE
Web UI: Kill the Flask server on exit.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,15 +2,15 @@
 
 > How can I change the demonstrations given to SWE-agent?
 
-At the start of each run, we feed the agent a demonstration trajectory, showing it how to solve an example issue. 
-This substantially improves the agent's abilities to solve novel issues. 
+At the start of each run, we feed the agent a demonstration trajectory, showing it how to solve an example issue.
+This substantially improves the agent's abilities to solve novel issues.
 If you'd like to modify or totally change this demonstration, to better fit your use case, see [this](config/demonstrations.md).
 
 > Does SWE-agent run on windows?
 
 You can run it in a [docker container](installation/docker.md), though this is not our first
-choice for running SWE-agent. SWE-agent runs best on Mac and Linux, as these are the environments we use for SWE-agent development. 
-We're open to merge simple fixes to make the [development setup](installation/source.md) work on Windows. 
+choice for running SWE-agent. SWE-agent runs best on Mac and Linux, as these are the environments we use for SWE-agent development.
+We're open to merge simple fixes to make the [development setup](installation/source.md) work on Windows.
 
 > Which LMs do you support?
 

--- a/start_web_ui.sh
+++ b/start_web_ui.sh
@@ -4,9 +4,12 @@ set -euo pipefail
 
 this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-function stop_react {
+function cleanup {
     echo "Stopping react server"
     npx --prefix "${this_dir}/sweagent/frontend" pm2 delete swe-agent
+    echo "Stopping Flask server"
+    kill "$flask_pid" 2>/dev/null
+    echo "Cleanup complete"
 }
 
 function print_log {
@@ -18,7 +21,7 @@ function print_log {
 
 cd "${this_dir}/sweagent/frontend"
 npm install
-trap stop_react exit
+trap cleanup EXIT
 npx pm2 start --name swe-agent npm -- start
 
 echo "* If you are running on your own machine, then a browser window "
@@ -34,6 +37,7 @@ echo "  web_api.log for error messages!"
 cd ../../
 trap print_log ERR
 python sweagent/api/server.py > web_api.log 2>&1 &
+flask_pid=$!
 
 wait -n
 exit $?


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/princeton-nlp/SWE-agent/issues/478

#### What does this implement/fix? Explain your changes.
This PR uses the PID returned when starting the Flask server to later clean up those processes on exit. This can avoid having to clean up manually before running the `start_web_ui` script again, or having to handle alternate ports or existing processes.

#### Testing Instructions
1. Run `./start_web_ui.sh`, then exit out of it.
2. Use `lsof -i :8000` to verify there are no processes on that port.
