### PR TITLE
Web UI: Start the Flask server first.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,15 +2,15 @@
 
 > How can I change the demonstrations given to SWE-agent?
 
-At the start of each run, we feed the agent a demonstration trajectory, showing it how to solve an example issue. 
-This substantially improves the agent's abilities to solve novel issues. 
+At the start of each run, we feed the agent a demonstration trajectory, showing it how to solve an example issue.
+This substantially improves the agent's abilities to solve novel issues.
 If you'd like to modify or totally change this demonstration, to better fit your use case, see [this](config/demonstrations.md).
 
 > Does SWE-agent run on windows?
 
 You can run it in a [docker container](installation/docker.md), though this is not our first
-choice for running SWE-agent. SWE-agent runs best on Mac and Linux, as these are the environments we use for SWE-agent development. 
-We're open to merge simple fixes to make the [development setup](installation/source.md) work on Windows. 
+choice for running SWE-agent. SWE-agent runs best on Mac and Linux, as these are the environments we use for SWE-agent development.
+We're open to merge simple fixes to make the [development setup](installation/source.md) work on Windows.
 
 > Which LMs do you support?
 

--- a/start_web_ui.sh
+++ b/start_web_ui.sh
@@ -16,6 +16,8 @@ function print_log {
     echo "----------"
 }
 
+trap print_log ERR
+python sweagent/api/server.py > web_api.log 2>&1 &
 cd "${this_dir}/sweagent/frontend"
 npm install
 trap stop_react exit
@@ -32,8 +34,6 @@ echo "* Something went wrong? Please check "
 echo "  web_api.log for error messages!"
 
 cd ../../
-trap print_log ERR
-python sweagent/api/server.py > web_api.log 2>&1 &
 
 wait -n
 exit $?


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/princeton-nlp/SWE-agent/issues/481

#### What does this implement/fix? Explain your changes.
This PR moves the Flask server startup to first in the script, which gives it (slightly) more time to write to `web_api.log` in the case of quick failures (such as in the case of https://github.com/princeton-nlp/SWE-agent/issues/480).

Honestly, we could also just stuff a `sleep 2` in `print_log` before the `cat` call (that also works, but involves a delay to output), or ignore it altogether (there isn't much likelihood of failures this quick – I just played with all of this because of the above issue).

Compare the above issue's output to this PR:

```
(venv) stuart 0 SWE-agent fix-empty-log-results > ./start_web_ui.sh

up to date, audited 1820 packages in 2s

349 packages are looking for funding
  run `npm fund` for details

8 vulnerabilities (2 moderate, 6 high)

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
[PM2] Starting /Users/kwight/Code/SDKs/n/bin/npm in fork_mode (1 instance)
[PM2] Done.
┌────┬────────────────────┬──────────┬──────┬───────────┬──────────┬──────────┐
│ id │ name               │ mode     │ ↺    │ status    │ cpu      │ memory   │
├────┼────────────────────┼──────────┼──────┼───────────┼──────────┼──────────┤
│ 0  │ swe-agent          │ fork     │ 0    │ online    │ 0%       │ 896.0kb  │
└────┴────────────────────┴──────────┴──────┴───────────┴──────────┴──────────┘
* If you are running on your own machine, then a browser window 
  should have already opened. If not, wait a few more seconds, then 
  open your browser at http://localhost:3000
* If you are running in github codespaces, please click the popup 
  that offers to forward port 3000 (not 8000!).
  Missed it? Find more information at 
  https://princeton-nlp.github.io/SWE-agent/installation/codespaces#running-the-web-ui
* Something went wrong? Please check 
  web_api.log for error messages!
./start_web_ui.sh: line 38: wait: -n: invalid option
wait: usage: wait [n]
Something went wrong. Here's web_api.log:
----------
keys.cfg not found in /Users/kwight/Code/SWE-agent/sweagent
2024-06-01 15:49:58,841 - werkzeug - WARNING - Werkzeug appears to be used in a production deployment. Consider switching to a production web server instead.
 * Serving Flask app 'server'
 * Debug mode: on
2024-06-01 15:49:58,842 - werkzeug - INFO - WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on http://127.0.0.1:8000
2024-06-01 15:49:58,842 - werkzeug - INFO - Press CTRL+C to quit
2024-06-01 15:49:58,842 - werkzeug - INFO -  * Restarting with stat
keys.cfg not found in /Users/kwight/Code/SWE-agent/sweagent
2024-06-01 15:49:59,714 - werkzeug - WARNING - Werkzeug appears to be used in a production deployment. Consider switching to a production web server instead.
2024-06-01 15:49:59,714 - werkzeug - WARNING -  * Debugger is active!
2024-06-01 15:49:59,719 - werkzeug - INFO -  * Debugger PIN: 484-945-261
----------
Stopping react server
[PM2] Applying action deleteProcessId on app [swe-agent](ids: [ 0 ])
[PM2] [swe-agent](0) ✓
┌────┬────────────────────┬──────────┬──────┬───────────┬──────────┬──────────┐
│ id │ name               │ mode     │ ↺    │ status    │ cpu      │ memory   │
└────┴────────────────────┴──────────┴──────┴───────────┴──────────┴──────────┘
(venv) stuart 2 SWE-agent fix-empty-log-results >
```

#### Testing Instructions
1. Introduce a typo towards the end of the script (this will simulate a fast error – eg. `wait` -> `ait` ¯\_(ツ)_/¯).
2. Run `./start_web_ui.sh`.
3. Verify the log is included in the script output (it would not be on `main`).
4. Note that the output won't have anything to do with this actual error, we just want to see the log on fast fails).