### PR TITLE
Web UI: Correct `class` usage.

### DIFF
--- a/sweagent/frontend/src/components/controls/LRunControl.js
+++ b/sweagent/frontend/src/components/controls/LRunControl.js
@@ -155,10 +155,10 @@ function LRunControl({
               defaultValue=""
             />
           </div>
-          <div class="input-group mb-3">
-            <div class="input-group-text">
+          <div className="input-group mb-3">
+            <div className="input-group-text">
               <input
-                class="form-check-input mt-0"
+                className="form-check-input mt-0"
                 type="checkbox"
                 aria-label="Run installation command"
                 defaultChecked={true}
@@ -173,7 +173,7 @@ function LRunControl({
             <span className="input-group-text">Installation command</span>
             <input
               type="text"
-              class="form-control"
+              className="form-control"
               aria-label="Text input with checkbox"
               placeholder={defaultInstallCommand}
               onChange={(e) =>


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/princeton-nlp/SWE-agent/issues/483

#### What does this implement/fix? Explain your changes.
It just keeps the console clean for when real problems come up. 🙃

| Before | After |
| --- | --- |
| <img width="1036" alt="Screenshot 2024-06-01 at 4 23 40 PM" src="https://github.com/princeton-nlp/SWE-agent/assets/349751/f4bd599d-8d54-4437-8fb4-0fb6195375ec"> | <img width="1036" alt="Screenshot 2024-06-01 at 4 35 06 PM" src="https://github.com/princeton-nlp/SWE-agent/assets/349751/9ba5c6a3-070e-4d73-aea1-f2727fb1539a"> |

#### Testing Instructions
1. Run `./start_web_ui.sh`.
2. Verify there are no warnings on the front-end in the console.


