### PR TITLE
Web UI: Render Markdown in agent feed messages.

### DIFF
--- a/sweagent/frontend/src/components/AgentMessage.js
+++ b/sweagent/frontend/src/components/AgentMessage.js
@@ -3,6 +3,7 @@ import React from "react";
 import "../static/message.css";
 import "../static/agentMessage.css";
 import { Gear } from "react-bootstrap-icons";
+import Markdown from "react-markdown";
 
 const AgentMessage = ({
   item,
@@ -21,7 +22,7 @@ const AgentMessage = ({
       onMouseLeave={handleMouseLeave}
     >
       {item.type !== "thought" && <Gear style={{ marginRight: 5 }} />}
-      <span>{item.message}</span>
+      <Markdown components={{ p: "span" }}>{item.message}</Markdown>
     </div>
   );
 };


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/princeton-nlp/SWE-agent/issues/485

#### What does this implement/fix? Explain your changes.
This PR uses the already-installed `react-markdown` package to render agent feed messages as markdown.

| Before | After |
| --- | --- |
| <img width="1235" alt="Screenshot 2024-06-01 at 5 03 48 PM" src="https://github.com/princeton-nlp/SWE-agent/assets/349751/a762566a-4ac0-4760-a047-8e17753b4d9b"> | <img width="1229" alt="Screenshot 2024-06-01 at 5 21 02 PM" src="https://github.com/princeton-nlp/SWE-agent/assets/349751/008b41e3-51b4-4e15-9b22-5d6d71d2de8b"> |

#### Testing Instructions
1. Run `./start_web_ui.sh`.
2. Set a problem source and click Run.
3. As content fills the agent feed (the "Thoughts" section), verify it's rendered as markdown, and not literally.

