### PR TITLE
Web UI: Reset the user-entered source value after changing the problem source dropdown.

### DIFF
--- a/sweagent/frontend/src/components/controls/LRunControl.js
+++ b/sweagent/frontend/src/components/controls/LRunControl.js
@@ -92,6 +92,23 @@ function LRunControl({
   }
 
   function getEnvInput() {
+    // Get environment configuration input controls based on the
+    // "Environment type" dropdown menu.
+    // if (envInputType === "conda") {
+    //   return (
+    //     <div className="input-group mb-3">
+    //       <span className="input-group-text">Conda environment</span>
+    //       <input
+    //         type="text"
+    //         className="form-control"
+    //         onChange={(e) =>
+    //           setRunConfig(draft => {draft.environment.environment_setup.packages = e.target.value})
+    //         }
+    //         placeholder="/path/to/conda_env.yml"
+    //       />
+    //     </div>
+    //   );
+    // }
     const envInputType = runConfig.environment.environment_setup.input_type;
     if (envInputType === "script_path") {
       return (

--- a/sweagent/frontend/src/components/controls/LRunControl.js
+++ b/sweagent/frontend/src/components/controls/LRunControl.js
@@ -1,10 +1,9 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Tab, Tabs } from "react-bootstrap";
 import Form from "react-bootstrap/Form";
-import "../../static/runControl.css";
 import { PlayFill, StopFill } from "react-bootstrap-icons";
-
 import { Link } from "react-router-dom";
+import "../../static/runControl.css";
 
 function LRunControl({
   isComputing,
@@ -19,17 +18,19 @@ function LRunControl({
 }) {
   // ps = problem statement
   const [psType, setPsType] = useState("gh");
+  const [psInputValue, setPsInputValue] = useState("");
   const defaultInstallCommand = "pip install --editable .";
-
   const defaultPS =
     "https://github.com/marshmallow-code/marshmallow/issues/1357";
-
-  const defaultRepo = "https://github.com/swe-agent-demo/marshmallow";
 
   const handlePsTypeChange = (event) => {
     const selectedType = event.target.value;
     setPsType(selectedType);
   };
+
+  useEffect(() => {
+    setPsInputValue("");
+  }, [psType]);
 
   function getPsInput() {
     // Problem statement input controls based on the value of the problem statement type
@@ -41,13 +42,14 @@ function LRunControl({
           <input
             type="text"
             className="form-control"
-            onChange={(e) =>
+            onChange={(e) => {
+              setPsInputValue(e.target.value);
               setRunConfig((draft) => {
                 draft.environment.data_path = e.target.value;
-              })
-            }
+              });
+            }}
             placeholder={"Example: " + defaultPS}
-            defaultValue=""
+            value={psInputValue}
           />
         </div>
       );
@@ -61,13 +63,14 @@ function LRunControl({
           <input
             type="text"
             className="form-control"
-            onChange={(e) =>
+            onChange={(e) => {
+              setPsInputValue(e.target.value);
               setRunConfig((draft) => {
                 draft.environment.data_path = e.target.value;
-              })
-            }
+              });
+            }}
             placeholder="/path/to/your/local/file.md"
-            defaultValue=""
+            value={psInputValue}
           />
         </div>
       );
@@ -89,23 +92,6 @@ function LRunControl({
   }
 
   function getEnvInput() {
-    // Get environment configuration input controls based on the
-    // "Environment type" dropdown menu.
-    // if (envInputType === "conda") {
-    //   return (
-    //     <div className="input-group mb-3">
-    //       <span className="input-group-text">Conda environment</span>
-    //       <input
-    //         type="text"
-    //         className="form-control"
-    //         onChange={(e) =>
-    //           setRunConfig(draft => {draft.environment.environment_setup.packages = e.target.value})
-    //         }
-    //         placeholder="/path/to/conda_env.yml"
-    //       />
-    //     </div>
-    //   );
-    // }
     const envInputType = runConfig.environment.environment_setup.input_type;
     if (envInputType === "script_path") {
       return (


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/princeton-nlp/SWE-agent/issues/362

#### What does this implement/fix? Explain your changes.
Use `useEffect` to monitor the problem source dropdown, and when it changes, reset the user value to empty (so that the default text appears for that field).

The textarea corresponding to the "Write" dropdown doesn't need changes since the actual markup is updated on switch (between `input`s and `textarea`).

![after](https://github.com/princeton-nlp/SWE-agent/assets/349751/494bad38-41fa-4266-ab2f-b7829d2d8994)

#### Testing Instructions
1. On a fresh page load, enter something into the "GitHub issue URL" field.
2. Switch the dropdown above it to "Local file", and verify the "Path to local .MD..." field is empty (displaying the placeholder text).
3. Enter data in that field again, and switch the dropdown back to its original value. Verify the "GitHub issue URL" field is empty again.
