### PR TITLE
Enh: Start from clone of python conda environment for speedup

### DIFF
--- a/docker/swe.Dockerfile
+++ b/docker/swe.Dockerfile
@@ -37,7 +37,8 @@ RUN conda --version \
     && conda init bash \
     && conda config --append channels conda-forge
 
-# Cache py3.10
+# Cache python versions
+RUN conda create -y -n python3.9 python=3.9
 RUN conda create -y -n python3.10 python=3.10
 
 # Install python packages

--- a/docker/swe.Dockerfile
+++ b/docker/swe.Dockerfile
@@ -37,6 +37,9 @@ RUN conda --version \
     && conda init bash \
     && conda config --append channels conda-forge
 
+# Cache py3.10
+RUN conda create -y -n python3.10 python=3.10
+
 # Install python packages
 COPY docker/requirements.txt /root/requirements.txt
 RUN pip install -r /root/requirements.txt

--- a/setup.sh
+++ b/setup.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 echo "Setting up docker image for swe-agent..."
 # TARGETARCH should be set automatically on most (but not all) systems, see
 # https://github.com/princeton-nlp/SWE-agent/issues/245
-docker build -t sweagent/swe-agent:exp -f docker/swe.Dockerfile --build-arg TARGETARCH=$(uname -m) .
+docker build -t sweagent/swe-agent:latest -f docker/swe.Dockerfile --build-arg TARGETARCH=$(uname -m) .
 
 echo "Setting up docker image for evaluation..."
-# docker build -t sweagent/swe-eval:latest -f docker/eval.Dockerfile .
+docker build -t sweagent/swe-eval:latest -f docker/eval.Dockerfile .
 
 echo "Done with setup!"

--- a/setup.sh
+++ b/setup.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 echo "Setting up docker image for swe-agent..."
 # TARGETARCH should be set automatically on most (but not all) systems, see
 # https://github.com/princeton-nlp/SWE-agent/issues/245
-docker build -t sweagent/swe-agent:latest -f docker/swe.Dockerfile --build-arg TARGETARCH=$(uname -m) .
+docker build -t sweagent/swe-agent:exp -f docker/swe.Dockerfile --build-arg TARGETARCH=$(uname -m) .
 
 echo "Setting up docker image for evaluation..."
-docker build -t sweagent/swe-eval:latest -f docker/eval.Dockerfile .
+# docker build -t sweagent/swe-eval:latest -f docker/eval.Dockerfile .
 
 echo "Done with setup!"

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -927,13 +927,31 @@ class SWEEnv(gym.Env):
                     logger.debug("Created conda environment with environment.yml")
                 self.communicate(f"rm {PATH_TO_ENV_YML}")
             else:
-                # Create environment + install packages
+                python_env = f"python{install_configs['python']}"
+                if self._conda_environment_exists(python_env):
+                    self.communicate_with_handling(
+                        f"conda create --name {env_name} --clone {python_env}",
+                        error_msg="Failed to clone conda environment",
+                        timeout_duration=LONG_TIMEOUT,
+                    )
+                    logger.debug("Cloned python conda environment")
+                else:
+                    self.communicate_with_handling(
+                        f"conda create -n {env_name} python={install_configs['python']} -y",
+                        error_msg="Failed to create conda environment",
+                        timeout_duration=LONG_TIMEOUT,
+                    )
                 self.communicate_with_handling(
-                    f"conda create -n {env_name} python={install_configs['python']} {packages} -y",
-                    error_msg="Failed to create conda environment",
-                    timeout_duration=LONG_TIMEOUT,
+                    f"conda activate {env_name}",
+                    error_msg="Failed to activate conda environment",
                 )
-                logger.debug("Created conda environment and installed packages")
+                if packages.strip():
+                    self.communicate_with_handling(
+                        f"conda install {packages} -y",
+                        error_msg="Failed to install packages",
+                        timeout_duration=LONG_TIMEOUT,
+                    )
+                    logger.debug("Installed conda packages")
             # Install extra pip packages if specified
             if install_configs.get("pip_packages"):
                 self.communicate_with_handling(

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -124,14 +124,12 @@ def test_execute_environment(tmp_path, test_env_args):
 
 @pytest.mark.slow()
 def test_execute_environment_clone_python_uv(tmp_path, test_env_args):
-    """This should clone the existing python 3.10 conda environment for speedup
-    and also use uv pip.
-    """
+    """This should clone the existing python 3.10 conda environment for speedup"""
     test_env = {
         "python": "3.10",
         "packages": "pytest",
         "pip_packages": ["tox"],
-        "install": "uv pip install -e .",
+        "install": "pip install -e .",
     }
     env_config_path = Path(tmp_path / "env_config.yml")
     env_config_path.write_text(yaml.dump(test_env))

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -129,7 +129,6 @@ def test_execute_environment_clone_python_uv(tmp_path, test_env_args):
         "python": "3.10",
         "packages": "pytest",
         "pip_packages": ["tox"],
-        "install": "pip install -e .",
     }
     env_config_path = Path(tmp_path / "env_config.yml")
     env_config_path.write_text(yaml.dump(test_env))

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -123,6 +123,24 @@ def test_execute_environment(tmp_path, test_env_args):
 
 
 @pytest.mark.slow()
+def test_execute_environment_clone_python_uv(tmp_path, test_env_args):
+    """This should clone the existing python 3.10 conda environment for speedup
+    and also use uv pip.
+    """
+    test_env = {
+        "python": "3.10",
+        "packages": "pytest",
+        "pip_packages": ["tox"],
+        "install": "uv pip install -e .",
+    }
+    env_config_path = Path(tmp_path / "env_config.yml")
+    env_config_path.write_text(yaml.dump(test_env))
+    test_env_args = dataclasses.replace(test_env_args, environment_setup=env_config_path)
+    with swe_env_context(test_env_args) as env:
+        env.reset()
+
+
+@pytest.mark.slow()
 def test_open_pr(test_env_args):
     test_env_args = dataclasses.replace(
         test_env_args,


### PR DESCRIPTION
Saves about 20s (out of 30s for setting up the conda env to begin with).

Currently only enabled for what's like the single issues (as opposed to the SWE-bench ones).

Todo:

* [x] Does this actually work with 3.9?
* [x] Test coverage will be broken until the new docker image is available after this PR is merged
* [x] Roll back setup.sh

Closes #491 