### PR TITLE
Fix: Process done marker not found in read with timeout

### DIFF
--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -641,7 +641,9 @@ class SWEEnv(gym.Env):
     ) -> str:
         """Experimental version of `_communicate`"""
         assert self.container is not None
-        command_suffix = f"echo {PROCESS_DONE_MARKER_START}$?{PROCESS_DONE_MARKER_END}\n"
+        # Sleep to ensure that the exit code is in the last line
+        # See https://github.com/princeton-nlp/SWE-agent/issues/595
+        command_suffix = f"sleep 0.01; echo {PROCESS_DONE_MARKER_START}$?{PROCESS_DONE_MARKER_END}\n"
         try:
             self.returncode = None
             cmd = input if input.endswith("\n") else input + "\n"

--- a/sweagent/environment/utils.py
+++ b/sweagent/environment/utils.py
@@ -238,10 +238,9 @@ def read_with_timeout_experimental(container: subprocess.Popen, timeout_duration
         raise TimeoutError(msg)
     decoded = buffer.decode()
     body = "\n".join(line for line in decoded.splitlines() if not line.startswith(PROCESS_DONE_MARKER_START))
-    last_line = decoded.splitlines()[-1]
-    _results = PROCESS_DONE_REGEX.search(last_line)
+    _results = PROCESS_DONE_REGEX.search(decoded)
     if _results is None:
-        msg = f"Could not find process done marker in last line: {last_line=}, {body=}"
+        msg = f"Could not find process done marker in last line: {decoded=}, {body=}"
         raise ValueError(msg)
     exit_code = _results.group(1)
     return body, exit_code

--- a/sweagent/environment/utils.py
+++ b/sweagent/environment/utils.py
@@ -226,8 +226,8 @@ def read_with_timeout_experimental(container: subprocess.Popen, timeout_duration
                 break
             if data:
                 buffer += data
-        if PROCESS_DONE_MARKER_START in buffer.decode():
-            break
+                if PROCESS_DONE_MARKER_START in buffer.decode():
+                    break
         time.sleep(0.01)  # Prevents CPU hogging
 
     if container.poll() is not None:


### PR DESCRIPTION
Closes #595 

Fix: Process done marker not found in read with timeout

This happened when both stderr and stdout were written to.
There was no guarantee that the suffix that prints the exit status would
actually be last.

Fix:
* Add a bit of timeout
* Search in all lines rather than just the last one for the exit code

Either of these should reasonably fix this.
