### PR TITLE
Issue #357: How to easily test flask API?

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+from flask_socketio import SocketIOTestClient
+
+from sweagent.api.server import app, socketio
+
+
+@pytest.fixture()
+def client():
+    with app.test_client() as client:
+        with app.app_context():
+            yield client
+
+
+@pytest.fixture()
+def socket_client():
+    client = SocketIOTestClient(app, socketio)
+    yield client
+    client.disconnect()
+
+
+def test_index(client):
+    """Test the index page"""
+    response = client.get("/")
+    assert response.status_code == 200
+
+
+def test_run_options(client):
+    """Test the /run endpoint OPTIONS method for CORS preflight"""
+    response = client.open("/run", method="OPTIONS")
+    assert response.status_code == 200
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+
+def test_stop(client):
+    """Test the /stop endpoint"""
+    response = client.get("/stop")
+    assert response.status_code == 202


### PR DESCRIPTION
Fixes #357 by adding basic test for high coverage of `api/server.py`

**What does this implement/fix? Explain your changes.**
- Creates basic flask client
- Tests the creation of client
- Tests the `"/run"` route 
- Tests the `"/stop"` route
