### PR TITLE
Add filemap command in the spirit of repomap

### DIFF
--- a/config/commands/filemap.py
+++ b/config/commands/filemap.py
@@ -1,0 +1,54 @@
+# @yaml
+# signature: filemap <file_path>
+# docstring: Print the contents of a Python file, skipping lengthy function and method definitions.
+# arguments:
+#   file_path:
+#       type: file path
+#       description: The path to the file to be read
+#       required: true
+
+from __future__ import annotations
+
+import argparse
+import warnings
+
+# tree_sitter is throwing a FutureWarning
+warnings.simplefilter("ignore", category=FutureWarning)
+from tree_sitter_languages import get_language, get_parser
+
+parser = argparse.ArgumentParser(
+    description="Print the contents of a Python file, skipping lengthy function and method definitions."
+)
+parser.add_argument("file_path", type=str, help="The path to the file to be read")
+args = parser.parse_args()
+
+# We assume that all input files are Python.
+parser = get_parser("python")
+language = get_language("python")
+file_contents = open(args.file_path).read()
+
+# We assume that files are utf8 encoded.
+tree = parser.parse(bytes(file_contents, "utf8"))
+
+# See https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries.
+query = language.query("""
+(function_definition
+  body: (_) @body)
+""")
+
+# TODO: consider special casing docstrings such that they are not elided. This
+# could be accomplished by checking whether `body.text.decode('utf8')` starts
+# with `"""` or `'''`.
+elide_line_ranges = [
+    (node.start_point[0], node.end_point[0])
+    for node, _ in query.captures(tree.root_node)
+    # Only elide if it's sufficiently long
+    if node.end_point[0] - node.start_point[0] >= 5
+]
+# Note that tree-sitter line numbers are 0-indexed, but we display 1-indexed.
+elide_lines = {line for start, end in elide_line_ranges for line in range(start, end + 1)}
+elide_messages = [(start, f"... eliding lines {start+1}-{end+1} ...") for start, end in elide_line_ranges]
+for i, line in sorted(
+    elide_messages + [(i, line) for i, line in enumerate(file_contents.splitlines()) if i not in elide_lines]
+):
+    print(f"{i+1:6d} {line}")

--- a/config/commands/filemap.py
+++ b/config/commands/filemap.py
@@ -1,3 +1,5 @@
+#!/root/miniconda3/bin/python
+
 # @yaml
 # signature: filemap <file_path>
 # docstring: Print the contents of a Python file, skipping lengthy function and method definitions.

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,4 +1,6 @@
 anthropic[bedrock]
 config
 openai
+tree-sitter==0.21.3 # See https://github.com/grantjenks/py-tree-sitter-languages/issues/64#issuecomment-2118048885.
+tree-sitter-languages
 uv


### PR DESCRIPTION
#### Reference Issues/PRs
n/a

#### What does this implement/fix? Explain your changes.

Adds a "filemap" command to aid in exploring large files/codebase and avoid `scroll_down`-hell. For example,
```
$ filemap SWE-agent/sweagent/agent/agents.py
...
   239 class Agent:
   240     """Agent handles the behaviour of the model and how it interacts with the environment."""
   241 
   242     def __init__(self, name: str, args: AgentArguments):
   243 ... eliding lines 243-256 ...
   257 
   258     def add_hook(self, hook: AgentHook):
   259         """Add hook to agent"""
   260         hook.on_init()
   261         self.hooks.append(hook)
   262 
   263     def _append_history(self, item: dict):
   264         for hook in self.hooks:
   265             hook.on_query_message_added(**item)
   266         self.history.append(item)
   267 
   268     def setup(self, instance_args, init_model_stats=None) -> None:
   269 ... eliding lines 269-322 ...
...
```
It is currently designed to elide any function or method definition that is at least 5 lines long. Changing this setting is straightforward.

There is currently no special handling for docstrings. If a function has a docstring it will be elided by default (unless the entire function body is less than 5 lines long).

Remaining TODOs:
- [ ] I have not verified that this command works within the SWE-agent docker environment, and I am not yet sure what the right approach is to test this.