### PR TITLE
Cap swebench version dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ openai>=1.0
 pandas
 rich
 ruamel.yaml
-swebench>=1.0.1
+swebench>=1.0.1,<2.0.0
 tenacity
 unidiff
 simple-parsing


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Caps the `swebench` package dependency `<2.0.0` to avoid breaking changes in the major version update.

We should update SWE-agent to use the new `swebench` package in the near future, but this should avoid issues with new users of SWE-agent.