### PR TITLE
ensure variables work in special command docstring

### DIFF
--- a/sweagent/agent/commands.py
+++ b/sweagent/agent/commands.py
@@ -243,7 +243,7 @@ class ParseCommandDetailed(ParseCommandBash):
         for cmd in commands + subroutine_types:
             docs += f"{cmd.name}:\n"
             if cmd.docstring is not None:
-                docs += f"  docstring: {cmd.docstring}\n"
+                docs += f"  docstring: {cmd.docstring.format(**kwargs)}\n"
             if cmd.signature is not None:
                 docs += f"  signature: {cmd.signature}\n"
             else:


### PR DESCRIPTION
SYSTEM message changes:

before: moves the window down {WINDOW} lines
after: moves the window down 100 lines

#### What does this implement/fix? Explain your changes.

I was playing it and found that in special commands section in the system message, `{WINDOW}` was not replaced with the desired value of `100`. Dig into it a little bit and I believe this should fix it. Not sure if there would be side effects tho.

![image](https://github.com/princeton-nlp/SWE-agent/assets/171245/1ee66adf-7008-4f34-886b-703b054d990b)
