### PR TITLE
Update pricing numbers for gpt-4o-mini-2024-07-18

### DIFF
--- a/docs/usage/coding_challenges.md
+++ b/docs/usage/coding_challenges.md
@@ -149,4 +149,4 @@ index 1e7f08f..beabaa7 100644
 
 ### Improving SWE-agent for coding challenges
 
-By default, the demonstration trajectory the agent uses while solving a coding challenge is one in which it needs to solve a small bug in a short piece of code (from the HumanEvalFix dataset). Since that process is not too similar to solving a coding challenge, performance would probably substantially improve if the agent was given a demonstration trajectory in which it has to solve an actual programming challenge. To learn how to do that, read [this](../config/demonstrations.md). 
+By default, the demonstration trajectory the agent uses while solving a coding challenge is one in which it needs to solve a small bug in a short piece of code (from the HumanEvalFix dataset). Since that process is not too similar to solving a coding challenge, performance would probably substantially improve if the agent was given a demonstration trajectory in which it has to solve an actual programming challenge. To learn how to do that, read [this](../config/demonstrations.md).

--- a/sweagent/agent/models.py
+++ b/sweagent/agent/models.py
@@ -227,8 +227,8 @@ class OpenAIModel(BaseModel):
         },
         "gpt-4o-mini-2024-07-18": {
             "max_context": 128_000,
-            "cost_per_input_token": 5e-06,
-            "cost_per_output_token": 15e-06,
+            "cost_per_input_token": 1.5e-07,
+            "cost_per_output_token": 6e-07,
         },
     }
 


### PR DESCRIPTION
#### Reference Issues/PRs
NA

#### What does this implement/fix? Explain your changes.
It looks like the current pricing figures for gpt-4o-mini are the same / copied from the pricing figures for gpt-4o. I believe they should be updated to reflect the OpenAI pricing page (5 per m input => .15 per m input, 15 per m output => .6 per m output)

Source: https://openai.com/api/pricing/
