### PR TITLE
Add GitLab support + AWS Bedrock Claude-3.5 and keys to keys.cfg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ flask
 flask-cors
 flask-socketio
 groq
+python-gitlab

--- a/sweagent/api/server.py
+++ b/sweagent/api/server.py
@@ -172,7 +172,7 @@ def run():
             ),
             config_file=CONFIG_DIR / "default_from_url.yaml",
         ),
-        actions=ActionsArguments(open_pr=False, skip_if_commits_reference_issue=True),
+        actions=ActionsArguments(open_pr=run.extra.open_pr, skip_if_commits_reference_issue=True),
         raise_exceptions=True,
     )
     thread = MainThread(defaults, wu)

--- a/sweagent/environment/swe_env.py
+++ b/sweagent/environment/swe_env.py
@@ -1176,8 +1176,8 @@ class SWEEnv(gym.Env):
         dry_run_flag = "--allow-empty" if _dry_run else ""
         issue_number = issue.number if "github.com" in issue_url else issue.iid
         commit_msg = [
-            shlex.quote("Fix: {issue.title}"),
-            shlex.quote("Closes #{issue_number}"),
+            shlex.quote(f"Fix: {issue.title}"),
+            shlex.quote(f"Closes #{issue_number}"),
         ]
         self.communicate_with_handling(
             input=f"git commit -m {commit_msg[0]} -m  {commit_msg[1]} {dry_run_flag}",

--- a/sweagent/environment/utils.py
+++ b/sweagent/environment/utils.py
@@ -596,8 +596,6 @@ def get_problem_statement_from_github_issue(owner: str, repo: str, issue_number:
 
 def get_problem_statement_from_gitlab_issue(owner: str, repo: str, issue_number: str, *, token: str | None = "") -> str:
     """Return problem statement from github issue"""
-    assert GITLAB_URL == "https://gitlab.devops.telekom.de"
-    assert token == "glpat-Ljs9Ao1zsY-j2yCoYV4Z"
     api = Gitlab(url=GITLAB_URL, private_token=token)
     project = api.projects.get(f"{owner}/{repo}")
     issue = project.issues.get(issue_number)

--- a/sweagent/frontend/src/Run.js
+++ b/sweagent/frontend/src/Run.js
@@ -42,6 +42,7 @@ function Run() {
     },
     extra: {
       test_run: false,
+      open_pr: true,
     },
   };
   const [runConfig, setRunConfig] = useImmer(runConfigDefault);

--- a/sweagent/frontend/src/components/controls/LRunControl.js
+++ b/sweagent/frontend/src/components/controls/LRunControl.js
@@ -330,6 +330,19 @@ function LRunControl({
               }
             />
           </div>
+          <div className="p-3">
+            <Form.Check
+              type="switch"
+              id="custom-switch"
+              label="Open PR"
+              checked={runConfig.extra.open_pr}
+              onChange={(e) =>
+                setRunConfig((draft) => {
+                  draft.extra.open_pr = e.target.checked;
+                })
+              }
+            />
+          </div>
         </Tab>
       </Tabs>
       <div className="runControl p-3">

--- a/sweagent/frontend/src/components/controls/LRunControl.js
+++ b/sweagent/frontend/src/components/controls/LRunControl.js
@@ -228,7 +228,7 @@ function LRunControl({
                 aria-label="Select problem statement type"
                 onChange={handlePsTypeChange}
               >
-                <option value="gh">GitHub issue URL</option>
+                <option value="gh">GitHub / GitLab issue URL</option>
                 <option value="local">Local file</option>
                 <option value="write">Write here</option>
               </select>


### PR DESCRIPTION
This patch includes changes to add GitLab support to SWE Agent. (E.g. for companies that use GitLab SaaS)

#### Reference Issues/PRs
N/A

#### What does this implement/fix? Explain your changes.
- Add support for GitLab issue URLs and repository URLs. GitLab endpoint can be configured using `GITLAB_URL` variable in `keys.cfg`. Gitlab Token can be configured using `GITLAB_TOKEN` in `keys.cfg`.
- Added support to create GitLab pull requests once patch is available and `--open_pr` has been used.
- Adding GitLab support introduced new dependency `python-gitlab` to `requirements.txt`
- Added Claude 3.5 Sonnet to available AWS Bedrock models
- Added possibility to supply `AWS_ACCESS_KEY`, `AWS_SECRET_KEY` and `AWS_REGION` to `keys.cfg` if desired.

