### PR TITLE
Update enigma.md

### DIFF
--- a/docs/usage/enigma.md
+++ b/docs/usage/enigma.md
@@ -31,8 +31,8 @@ python run.py \
   --model_name gpt4 \
   --ctf \
   --image_name sweagent/enigma:latest \
-  --data_path ../LLM_CTF_Database/2018/CSAW-Finals/misc/leaked_flag/challenge.json \
-  --repo_path ../LLM_CTF_Database/2018/CSAW-Finals/misc/leaked_flag \
+  --data_path ../NYU_CTF_Bench/test/2018/CSAW-Finals/misc/leaked_flag/challenge.json \
+  --repo_path ../NYU_CTF_Bench/test/2018/CSAW-Finals/misc/leaked_flag/ \
   --config_file config/default_ctf.yaml \
   --per_instance_cost_limit 2.00
 ```


### PR DESCRIPTION
Enigma getting started example uses out of date directory structure in the data_path and repo_path arguments.

<!--
Thanks for contributing a pull request!
-->

#### Reference Issues/PRs
N/A

#### What does this implement/fix? Explain your changes.

Enigma getting started example uses out of date directory structure in the data_path and repo_path arguments.
Changes `/LLM_CTF_Database/2018/CSAW-Finals/misc/leaked_flag/` to `/NYU_CTF_Bench/test/2018/CSAW-Finals/misc/leaked_flag/`
Tested successfully. 

