### PR TITLE
Improved Clarity in Demonstration, Summarizer, and Command Configuration

### DIFF
--- a/docs/config/commands.md
+++ b/docs/config/commands.md
@@ -29,7 +29,7 @@ Every command subscribes to the following skeleton code.
 * The minimal documentation requirements are `signature` and `docstring`.
 * If you'd like multiple commands to make modifications to a similar body of functions, we recommend using global variables.
     * For instance, in `config/commands/default.sh`, you'll see we define the `CURRENT_LINE` variable for the file viewer. This variable is modified across multiple commands, including `open`, `goto`, `scroll_up`, `scroll_down`, and `edit`.
-    * You can also leverage third party libraries (check out how we do linting enabled `edit` in `config/commands/edit_linting.sh`).
+    * You can also third-party libraries (check out how we enable linting in `config/commands/edit_linting.sh`).
 * To show effects of the command, print to standard output (i.e. `echo`). SWE-agent is implemented such that it does not look for a return value from these commands.
 * The following environment variables are used to persist information between commands:
     * `CURRENT_FILE`: File that is currently open

--- a/docs/config/demonstrations.md
+++ b/docs/config/demonstrations.md
@@ -2,7 +2,7 @@
 
 An important way to show LMs how to use commands and interact with the environment is through providing a demonstration - which is basically a completed [trajectory](../usage/trajectories.md) that the LM can learn from.
 
-For simplicity we only ingest demonstrations in the from of a trajectory file. However, since trajectory files are usually JSON, you can convert them to yaml using the `make_demos/convert_traj_to_demo.py` script to be more human-readable and easier to edit.
+For simplicity we only ingest demonstrations in the form of a trajectory file. However, since trajectory files are usually JSON, you can convert them to yaml using the `make_demos/convert_traj_to_demo.py` script to be more human-readable and easier to edit.
 
 Demo (yaml) files are stored in the `make_demos/demos` directory by default and consist primarily of the sequence of actions that an LM would need to take to complete a task. It's important that your demo have the proper format to be parsed by SWE-agent and your config.
 

--- a/docs/config/summarizers.md
+++ b/docs/config/summarizers.md
@@ -11,7 +11,7 @@ The summarizer configuration is defined within the main [configuration](config.m
 ```yaml
 summarizer_config:
   function: Reference to functionality of the summarizer. Can be one of SimpleSummarizer, LMSummarizer or Identity
-  window_length: Threshold of the line count limit. Observation output exceeding these number, will be summarized.
+  window_length: Threshold of the line count limit. Observation output exceeding this number will be summarized.
   system_template: |-
     First `system` message shown to the LMSummarizer.
     This has no effect in other summarizer functionalities.


### PR DESCRIPTION
Corrected minor phrasing issues in demonstration, summarizer, and command configuration docs for clarity.
- The phrase "Observation output exceeding these number, will be summarized" corrected to "Observation output exceeding this number will be summarized."
- "we only ingest demonstrations in the from of a trajectory file" corrected to "we only ingest demonstrations in the form of a trajectory file."
- "You can also leverage third party libraries (check out how we do linting enabled edit in config/commands/edit_linting.sh)" corrected to "You can also leverage third-party libraries (check out how we enable linting in config/commands/edit_linting.sh)."